### PR TITLE
Failing topic creation if it's in ZK's /admin/delete_topics list

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ val metricsVersion = "4.0.5"
 val kafkaVersion = "2.0.0" // Any version higher than 2.0.0 changes the KafkaConsumer.beginningOffsets()'s behaviour and makes it time-out if only a single topic-partition has no leader or some metadata-problem.
                            // This is really bad, because it can happen sometimes and then we won't have any lag monitoring (and low/high offset metrics) for the whole cluster.
                            // Unfortunately this old version fails on e.g. consuming zstd compressed message batches, which makes the consume-after-consumer-group feature (to detect fake-lags) less useful.
+val curatorVersion = "5.5.0"
 
 val dnsDeps = Seq(
   "dnsjava" % "dnsjava" % "2.1.8"
@@ -85,6 +86,10 @@ val sqlDeps = Seq(
 
 val kafkaDeps = Seq(
   "org.apache.kafka" %% "kafka" % kafkaVersion
+)
+
+val curatorDeps = Seq(
+  "org.apache.curator" % "curator-framework" % curatorVersion
 )
 
 val testDeps = Seq(
@@ -187,7 +192,7 @@ lazy val `kewl-kafkacluster-processor` = (project in file("kewl-kafkacluster-pro
     name := "kewl-kafkacluster-processor",
     headerLicense := license,
     libraryDependencies ++= configDeps ++ catsDeps ++ loggingDeps ++ akkaDeps ++ akkaHttpDeps
-      ++ jsonDeps ++ kafkaDeps ++ testDeps ++ metricsDeps
+      ++ jsonDeps ++ kafkaDeps ++ curatorDeps ++ testDeps ++ metricsDeps
   )
 
 lazy val `kewl-api` = (project in file("kewl-api"))

--- a/kewl-api/src/main/resources/prometheus.yaml
+++ b/kewl-api/src/main/resources/prometheus.yaml
@@ -17,3 +17,18 @@ rules:
       metric: "$3"
       result: "$4"
       type: "$5"
+  - pattern: 'kafkakewl-api<name=\"com\.mwam\.kafkakewl\.processor\.kafkacluster\.zk_get_deleted_topics_failed\:(.+)\"><>(.+): (.+)'
+    type: UNTYPED
+    name: "kafkakewl_zk_get_deleted_topics_failed"
+    value: "$3"
+    labels:
+      kafkaCluster: "$1"
+      type: "$2"
+  - pattern: 'kafkakewl-api<name=\"com\.mwam\.kafkakewl\.processor\.kafkacluster\.not_created_pending_deleted_topic\:(.+)\:(.+)\"><>(.+): (.+)'
+    type: UNTYPED
+    name: "kafkakewl_not_created_pending_deleted_topic"
+    value: "$4"
+    labels:
+      kafkaCluster: "$1"
+      topic: "$2"
+      type: "$3"

--- a/kewl-domain/src/main/scala/com/mwam/kafkakewl/domain/kafkacluster/KafkaCluster.scala
+++ b/kewl-domain/src/main/scala/com/mwam/kafkakewl/domain/kafkacluster/KafkaCluster.scala
@@ -17,6 +17,8 @@ final case class KafkaClusterEntityId(id: String) extends AnyVal with EntityId
   *
   * @param kafkaCluster the kafka-cluster id (only so that the json can specify it)
   * @param brokers the list of brokers
+  * @param zooKeeper the optional list of the zookeeper hosts (to avoid creating topics if they are pending-deleted in the '/admin/delete_topics')
+  * @param zooKeeperRetryIntervalMs the zookeeper connection retry interval milliseconds, defaulting to 3000
   * @param securityProtocol the optional security protocol (if none, the default is used which is PLAINTEXT)
   * @param kafkaClientConfig the optional kafka client config that overrides everything else
   * @param name the optional human readable name of the kafka cluster
@@ -35,6 +37,8 @@ final case class KafkaClusterEntityId(id: String) extends AnyVal with EntityId
 final case class KafkaCluster(
   kafkaCluster: KafkaClusterEntityId, // the only reason of this being here is that the input json can tell the kafka-cluster id
   brokers: String,
+  zooKeeper: Option[String] = None,
+  zooKeeperRetryIntervalMs: Option[Int] = None,
   securityProtocol: Option[String] = None,
   kafkaClientConfig: Map[String, String] = Map.empty,
   name: String = "",

--- a/kewl-kafkacluster-processor/src/main/scala/com/mwam/kafkakewl/processor/kafkacluster/KafkaClusterAdmin.scala
+++ b/kewl-kafkacluster-processor/src/main/scala/com/mwam/kafkakewl/processor/kafkacluster/KafkaClusterAdmin.scala
@@ -199,7 +199,10 @@ private[kafkacluster] class DefaultKafkaClusterAdmin(
           }
         } yield {
           // combining the 2 KafkaOperationResults' logs (they have no values)
-          deleteTopicsCheckResult.flatMap(_ => createTopicResult)
+          for { // based on KafkaOperationResult = Writer[Vector[String], _]
+            _ <- deleteTopicsCheckResult
+            _ <- createTopicResult
+          } yield ()
         }
 
       case KafkaClusterChange.Add(acl: KafkaClusterItem.Acl) =>

--- a/kewl-kafkacluster-processor/src/main/scala/com/mwam/kafkakewl/processor/kafkacluster/KafkaClusterCommandProcessorActor.scala
+++ b/kewl-kafkacluster-processor/src/main/scala/com/mwam/kafkakewl/processor/kafkacluster/KafkaClusterCommandProcessorActor.scala
@@ -92,7 +92,7 @@ class KafkaClusterCommandProcessorActor(
       logger.info("skipping validating the deployment state store")
     }
 
-    kafkaClusterAdmin = new DefaultKafkaClusterAdmin(config.kafkaClusterId, config.connection, config.kafkaCluster.kafkaRequestTimeOutMillis)
+    kafkaClusterAdmin = new DefaultKafkaClusterAdmin(config.kafkaClusterId, config.connection, config.kafkaCluster)
     kafkaClusterCommandProcessor = new KafkaClusterCommandProcessing(config.kafkaClusterId, config.connection, kafkaClusterAdmin, config.topicDefaults)
 
     context.parent ! KafkaClusterCommandProcessorActor.DeployedTopologies(config.kafkaClusterId, inMemoryStateStores.deployedTopology.getLatestLiveStates)


### PR DESCRIPTION
Otherwise kafka gets confused and it may re-use the old topics' logs or the topic may get into a bad state where we can't retrieve its metadata.