### PR TITLE
Using the default MAX_PARTITION_FETCH_BYTES_CONFIG when consuming the…

### DIFF
--- a/kewl-api-metrics/src/main/scala/com/mwam/kafkakewl/api/metrics/kafkacluster/groups/collectors/KafkaClusterConsumerGroupOffsetsConsumer.scala
+++ b/kewl-api-metrics/src/main/scala/com/mwam/kafkakewl/api/metrics/kafkacluster/groups/collectors/KafkaClusterConsumerGroupOffsetsConsumer.scala
@@ -208,7 +208,7 @@ class KafkaClusterConsumerGroupOffsetsConsumer(
     for {
       // consuming the consumer-offsets topic until the end, compacting, getting the latest values for keys
       latestConsumerOffsets <- KafkaUpsertConsumer.loadLatestKeyValuesOfTopic[ConsumerGroupTopicPartition, ConsumerGroupOffset](
-        helper.connection.withConfig(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "20971520"), // to speed up the initial load
+        helper.connection,
         consumerOffsetsTopicName,
         noOfThreadsForInitialLoad,
         logger.some,


### PR DESCRIPTION
… __consumer_offsets topic to avoid fetch requests timing out