### PR TITLE
Feat: Remove metric timestamp regex

### DIFF
--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
@@ -29,7 +29,7 @@ class Endpoints(
     .fromServerEndpoints[Task](apiEndpoints, "kafkakewl-deploy", "1.0.0")
 
   private def getMetrics: ZIO[Any, Unit, String] =
-    prometheusPublisher.get // TODO this adds the timestamp as well which isn't desirable due to prometheus's staleness handling
+    prometheusPublisher.get.map(_.replaceAll("[0-9]+\n", "\n"))
 }
 
 object Endpoints {

--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
@@ -28,6 +28,7 @@ class Endpoints(
   private def docsEndpoints(apiEndpoints: List[ZServerEndpoint[Any, Any]]): List[ZServerEndpoint[Any, Any]] = SwaggerInterpreter()
     .fromServerEndpoints[Task](apiEndpoints, "kafkakewl-deploy", "1.0.0")
 
+  // Regex to remove timestamp from the end of each metric. This is to fix the staleness issue in prometheus.
   private def getMetrics: ZIO[Any, Unit, String] =
     prometheusPublisher.get.map(_.replaceAll("[0-9]+\n", "\n"))
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/Endpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/Endpoints.scala
@@ -30,7 +30,7 @@ class Endpoints(
     .fromServerEndpoints[Task](apiEndpoints, "kafkakewl-metrics", "1.0.0")
 
   private def getMetrics: ZIO[Any, Unit, String] =
-    prometheusPublisher.get // TODO this adds the timestamp as well which isn't desirable due to prometheus's staleness handling
+    prometheusPublisher.get.map(_.replaceAll("[0-9]+\n", "\n"))
 }
 
 object Endpoints {

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/Endpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/Endpoints.scala
@@ -29,6 +29,7 @@ class Endpoints(
   private def docsEndpoints(apiEndpoints: List[ZServerEndpoint[Any, Any]]): List[ZServerEndpoint[Any, Any]] = SwaggerInterpreter()
     .fromServerEndpoints[Task](apiEndpoints, "kafkakewl-metrics", "1.0.0")
 
+  // Regex to remove timestamp from the end of each metric. This is to fix the staleness issue in prometheus.
   private def getMetrics: ZIO[Any, Unit, String] =
     prometheusPublisher.get.map(_.replaceAll("[0-9]+\n", "\n"))
 }


### PR DESCRIPTION
Removed metric timestamps by performing a regex on the string, looking for a number followed by a newline (as the timestamp is always the final value on the line.