### PR TITLE
Feat: Add health checks to kafkakewl metrics

### DIFF
--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/Endpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/Endpoints.scala
@@ -19,11 +19,25 @@ class Endpoints(
 ) {
   private val metricsEndpoint: PublicEndpoint[Unit, Unit, String, Any] = endpoint.in("metrics").get.out(stringBody)
 
+  // Health check endpoints. As of now, just return 200 no preparation is done
+  // after the HTTP server starts.
+  private val livenessEndpoint: PublicEndpoint[Unit, Nothing, Unit, Any] =
+    infallibleEndpoint.in("health").in("live").get
+  private val readinessEndpoint: PublicEndpoint[Unit, Nothing, Unit, Any] =
+    infallibleEndpoint.in("health").in("ready").get
+  private val startupProbeEndpoint: PublicEndpoint[Unit, Nothing, Unit, Any] =
+    infallibleEndpoint.in("health").in("startup").get
+
   val endpoints: List[ZServerEndpoint[Any, Any]] = {
     val api = topicEndpoints.endpoints ++ consumerGroupEndpoints.endpoints
     val docs = docsEndpoints(api)
     val metrics = List(metricsEndpoint.zServerLogic[Any](_ => getMetrics))
-    api ++ docs ++ metrics
+    val health =
+      List(livenessEndpoint, readinessEndpoint, startupProbeEndpoint)
+        .map(
+          _.zServerLogic[Any](_ => ZIO.succeed(()))
+        )
+    api ++ docs ++ metrics ++ health
   }
 
   private def docsEndpoints(apiEndpoints: List[ZServerEndpoint[Any, Any]]): List[ZServerEndpoint[Any, Any]] = SwaggerInterpreter()


### PR DESCRIPTION
Add the following HTTP healthcheck endpoints to the metrics service:
/health/live
/health/ready
/health/startup

Currently, these always return status code 200 (OK), as setup is always completed before HTTP server comes online.