### PR TITLE
Feat: Use noop OTEL tracer if relevant environment variables are not set

### DIFF
--- a/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/telemetry/GlobalTracer.scala
+++ b/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/telemetry/GlobalTracer.scala
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
 import zio.{TaskLayer, ZIO, ZLayer, System}
 
 object GlobalTracer {
+  // Will not
   val live: TaskLayer[Tracer] =
     ZLayer.fromZIO(
       {
@@ -19,7 +20,6 @@ object GlobalTracer {
           _ <- System.env("OTEL_EXPORTER_OTLP_ENDPOINT").flatMap(zio.ZIO.fromOption)
           _ <- System.env("OTEL_EXPORTER_OTLP_PROTOCOL").flatMap(zio.ZIO.fromOption)
           _ <- System.env("OTEL_SERVICE_NAME").flatMap(zio.ZIO.fromOption)
-          _ <- System.env("OTEL_TRACES_EXPORTER").flatMap(zio.ZIO.fromOption)
         } yield AutoConfiguredOpenTelemetrySdk.initialize.getOpenTelemetrySdk.getTracer(getClass.getPackageName)
       }
         .orElse(ZIO.succeed(OpenTelemetry.noop().getTracer(getClass.getPackageName)))

--- a/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/telemetry/GlobalTracer.scala
+++ b/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/telemetry/GlobalTracer.scala
@@ -6,13 +6,22 @@
 
 package com.mwam.kafkakewl.common.telemetry
 
-import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.{DefaultTracer, Tracer}
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
-import zio.{TaskLayer, ZIO, ZLayer}
+import zio.{TaskLayer, ZIO, ZLayer, System}
 
 object GlobalTracer {
   val live: TaskLayer[Tracer] =
     ZLayer.fromZIO(
-      ZIO.attempt(AutoConfiguredOpenTelemetrySdk.initialize.getOpenTelemetrySdk.getTracer(getClass.getPackageName))
+      {
+        for {
+          _ <- System.env("OTEL_EXPORTER_OTLP_ENDPOINT").flatMap(zio.ZIO.fromOption)
+          _ <- System.env("OTEL_EXPORTER_OTLP_PROTOCOL").flatMap(zio.ZIO.fromOption)
+          _ <- System.env("OTEL_SERVICE_NAME").flatMap(zio.ZIO.fromOption)
+          _ <- System.env("OTEL_TRACES_EXPORTER").flatMap(zio.ZIO.fromOption)
+        } yield AutoConfiguredOpenTelemetrySdk.initialize.getOpenTelemetrySdk.getTracer(getClass.getPackageName)
+      }
+        .orElse(ZIO.succeed(OpenTelemetry.noop().getTracer(getClass.getPackageName)))
     )
 }


### PR DESCRIPTION
Without the OpenTelemetry environment variables set, Kafkakewl will attempt to push metrics/traces to a default collector, which gives error messages like:
```
Sept 14, 2023 9:26:55 PM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
WARNING: Failed to export metrics. Server responded with gRPC status code 2. Error message: Failed to connect to localhost/127.0.0.1:4317
``` 

To get around this, the GlobalTracer layer `live` looks for the following environment variables to be set:
- OTEL_EXPORTER_OTLP_ENDPOINT
- OTEL_EXPORTER_OTLP_PROTOCOL
- OTEL_SERVICE_NAME

If these environment variables are not set, then a noop tracer is used instead of the default AutoConfiguredOpenTelemetrySdk. 