### PR TITLE
Fix: upgrading to scala 3.3.1 to fix the compile on jdk21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val orgName = "Marshall Wace"
 val year = 2023
 
-ThisBuild / scalaVersion        := "3.3.0"
+ThisBuild / scalaVersion        := "3.3.1"
 ThisBuild / version             := "0.1.0-SNAPSHOT"
 ThisBuild / organization        := "com.mwam.kafkakewl"
 ThisBuild / organizationName    := orgName


### PR DESCRIPTION
at `sbt compile`, I was getting:

```
[error] error while loading ElementType,
[error] class file /modules/java.base/java/lang/annotation/ElementType.class is broken, reading aborted with class java.lang.RuntimeException
[error] bad constant pool index: 0 at pos: 1220
```

The scala upgrade seems to have fixed it.