### PR TITLE
Feat: deploying to kafka - KafkaClusterItem and the unimplemented factory functions

### DIFF
--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/kafka/KafkaClusterItem.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/kafka/KafkaClusterItem.scala
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Marshall Wace <opensource@mwam.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.mwam.kafkakewl.deploy.kafka
+
+import org.apache.kafka.common.resource.PatternType
+import zio.kafka.admin.acl.{AclOperation, AclPermissionType}
+import zio.kafka.admin.resource.ResourceType
+
+/** Base trait of all kafka cluster items (which are really just topics and acls).
+  */
+sealed trait KafkaClusterItem {
+  val key: String
+  val isReal = true
+}
+
+object KafkaClusterItem {
+
+  /** A kafka-cluster item to represent a kafka topic.
+    *
+    * @param isReal
+    *   true if it's an actual topic that should exist in the cluster or false if it's an un-managed topic which may or may not exist
+    */
+  final case class Topic(
+      name: String,
+      partitions: Int = 1,
+      replicationFactor: Short = 3,
+      config: Map[String, String],
+      override val isReal: Boolean = true
+  ) extends KafkaClusterItem {
+    val key: String = s"topic:$name"
+  }
+
+  /** A kafka cluster item to represent a kafka acl.
+    *
+    * @note
+    *   For now we use the zio.kafka types here, but if needed we can switch back to the vanilla kafka ones.
+    */
+  final case class Acl(
+      resourceType: ResourceType,
+      resourcePatternType: PatternType,
+      resourceName: String,
+      principal: String,
+      host: String,
+      operation: AclOperation,
+      permission: AclPermissionType
+  ) extends KafkaClusterItem {
+
+    /** The key of the acl is itself with all its fields. It's not possible to "update" and acl, only add or remove.
+      */
+    val key: String = s"acl:$resourceType/$resourcePatternType/$resourceName/$principal/$host/$operation/$permission"
+  }
+}

--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/kafka/KafkaClusterItems.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/kafka/KafkaClusterItems.scala
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Marshall Wace <opensource@mwam.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.mwam.kafkakewl.deploy.kafka
+
+import com.mwam.kafkakewl.domain.Topologies
+import zio.*
+import zio.kafka.admin.AdminClient
+
+// TODO Should this be a service? Don't think so, it's stateless, no lifecycle, it's really just a pure function. We'll see.
+object KafkaClusterItems {
+
+  /** Creates the [[KafkaClusterItem]]s for the given topologies.
+    *
+    * @param topologies
+    *   the topologies
+    * @param isKafkaClusterSecurityEnabled
+    *   a boolean flag indicating whether the cluster supports security (acls) or not
+    */
+  def forTopologies(
+      topologies: Topologies,
+      isKafkaClusterSecurityEnabled: Boolean
+      // TODO we'll probably need some topic defaults description for e.g. default external consumer/producer namespaces, etc... to find out all relationships for topologies so that developers can get those acls
+      // TODO we'll probably need a function that resolves the topics' replica placement id and populates it into the topic config - alternatively we can do that outside
+  ): Seq[KafkaClusterItem] = {
+    ???
+  }
+
+  /** Creates the [[KafkaClusterItem]]s that exist in the given kafka cluster.
+    *
+    * @param adminClient
+    *   the admin client to use
+    */
+  def forKafkaCluster(adminClient: AdminClient): Task[Seq[KafkaClusterItem]] = {
+    ???
+  }
+}


### PR DESCRIPTION
The `KafkaClusterItem` type (Topic or Acl) is what the deployment logic will work with. First we'll generate them for all topologies (= desired state), then retrieve it from the kafka-cluster (= actual state), and deploy what's missing or different (with safety rules and trying to deploy changes only for the topologies that currently being deployed)