### PR TITLE
Removed traditional Kafka consumer and replaced with ZIO consumer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ ThisBuild / scalacOptions ++= Seq(
   "-feature"
 )
 
+ThisBuild / testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+
 // Have to do this for the root project and enable it for the sub-projects as well as setting the headerLicense for them.
 disablePlugins(HeaderPlugin)
 
@@ -71,7 +73,8 @@ val zio = Seq(
   "dev.zio" %% "zio-logging" % zioLoggingVersion,
   "dev.zio" %% "zio-logging-slf4j" % zioLoggingVersion,
   "dev.zio" %% "zio-kafka" % zioKafkaVersion,
-  "com.softwaremill.sttp.client3" %% "zio-json" % tapirZioJsonVersion % Test
+  "com.softwaremill.sttp.client3" %% "zio-json" % tapirZioJsonVersion % Test,
+  "dev.zio" %% "zio-kafka-testkit" % zioKafkaVersion % Test
 )
 
 val config = Seq(
@@ -151,8 +154,7 @@ lazy val deploy = project
     // disabling scalaDoc fixes it (it's needed because stage wants to generate scalaDoc)
     packageDoc / publishArtifact := false,
     Compile / mainClass := Some("com.mwam.kafkakewl.deploy.Main"),
-    libraryDependencies ++= tapir ++ tapirCore ++ config ++ zio ++ tests ++ logging,
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+    libraryDependencies ++= tapir ++ tapirCore ++ config ++ zio ++ tests ++ logging
   )
 
 lazy val metrics = project
@@ -168,6 +170,5 @@ lazy val metrics = project
     // disabling scalaDoc fixes it (it's needed because stage wants to generate scalaDoc)
     packageDoc / publishArtifact := false,
     Compile / mainClass := Some("com.mwam.kafkakewl.metrics.Main"),
-    libraryDependencies ++= tapir ++ tapirCore ++ config ++ zio ++ tests ++ logging,
-    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+    libraryDependencies ++= tapir ++ tapirCore ++ config ++ zio ++ tests ++ logging
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,33 @@
 val orgName = "Marshall Wace"
 val year = 2023
 
-ThisBuild / scalaVersion        := "3.3.1"
-ThisBuild / version             := "0.1.0-SNAPSHOT"
-ThisBuild / organization        := "com.mwam.kafkakewl"
-ThisBuild / organizationName    := orgName
-ThisBuild / startYear           := Some(year)
+ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / organization := "com.mwam.kafkakewl"
+ThisBuild / organizationName := orgName
+ThisBuild / startYear := Some(year)
 
-ThisBuild / scalacOptions       ++= Seq(
-  "-Xmax-inlines", "64",
+ThisBuild / scalacOptions ++= Seq(
+  "-Xmax-inlines",
+  "64",
   "-Yretain-trees", // so that zio-json supports default values
-  "-Wunused:imports", "-Wunused:params", "-deprecation", "-feature"
+  "-Wunused:imports",
+  "-Wunused:params",
+  "-deprecation",
+  "-feature"
 )
 
 // Have to do this for the root project and enable it for the sub-projects as well as setting the headerLicense for them.
 disablePlugins(HeaderPlugin)
 
-val license = Some(HeaderLicense.Custom(
-  s"""SPDX-FileCopyrightText: $year $orgName <opensource@mwam.com>
+val license = Some(
+  HeaderLicense.Custom(
+    s"""SPDX-FileCopyrightText: $year $orgName <opensource@mwam.com>
      |
      |SPDX-License-Identifier: Apache-2.0
      |""".stripMargin
-))
+  )
+)
 
 val logbackVersion = "1.4.11"
 val logbackContribJsonVersion = "0.1.5"
@@ -44,7 +50,7 @@ val tapir = Seq(
   "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server" % tapirVersion,
   "com.softwaremill.sttp.tapir" %% "tapir-json-zio" % tapirVersion,
   "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion,
-  "com.softwaremill.sttp.tapir" %% "tapir-zio-metrics" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-zio-metrics" % tapirVersion
 )
 
 val tapirCore = Seq(
@@ -75,7 +81,7 @@ val config = Seq(
 )
 
 val circeYaml = Seq(
-    "io.circe" %% "circe-yaml" % circeYamlVersion
+  "io.circe" %% "circe-yaml" % circeYamlVersion
 )
 
 val kafkaClient = Seq(
@@ -95,7 +101,7 @@ val telemetry = Seq(
   "io.opentelemetry" % "opentelemetry-extension-trace-propagators" % openTelemetryVersion,
   "io.opentelemetry" % "opentelemetry-semconv" % s"$openTelemetryVersion-alpha",
   "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % openTelemetryVersion,
-  "io.grpc" % "grpc-netty-shaded" % openTelemetryGrpcVersion,
+  "io.grpc" % "grpc-netty-shaded" % openTelemetryGrpcVersion
 )
 
 val tests = Seq(

--- a/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/kafka/KafkaConsumerUtils.scala
+++ b/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/kafka/KafkaConsumerUtils.scala
@@ -37,24 +37,28 @@ object KafkaConsumerUtils {
   extension (compactedConsumeResult: CompactedConsumeResult[Bytes, Bytes]) {
     def deserialize[Key, Value <: AnyRef](
         topic: String,
-        keyDeserializer: Deserializer[Any, Key],
+        keyDeserializer: Deserializer[Any, Option[Key]],
         valueDeserializer: Deserializer[Any, Value]
-    ): UIO[CompactedConsumeResult[Key, Value]] = {
+    ): URIO[Any, CompactedConsumeResult[Key, Value]] = {
 
       for {
-        lastVals <- ZIO.collect(compactedConsumeResult.lastValues) {
-          case (keyBytes, valueBytesOption) => {
-            val key = keyDeserializer
-              .deserialize(topic, new RecordHeaders(), keyBytes.get())
-            val value = ZIO
-              .fromOption(valueBytesOption)
-              .flatMap(valueBytes => valueDeserializer.deserialize(topic, new RecordHeaders(), valueBytes.get()).option)
-              .orElseSucceed(None)
+        lastVals <- ZIO.collectAllSuccesses(compactedConsumeResult.lastValues.map { case (keyBytes, valueBytesOption) =>
+          val key = keyDeserializer
+            .deserialize(topic, new RecordHeaders(), keyBytes.get())
+            .some
+            .orElseFail(None)
+          val value = ZIO
+            .fromOption(valueBytesOption)
+            .flatMap(valueBytes => valueDeserializer.deserialize(topic, new RecordHeaders(), valueBytes.get()).option)
+            .orElseSucceed(None)
 
-            key.zipWith(value)((key, value) => (key, value)).mapError(_ => None): IO[Option[Nothing], (Key, Option[Value])]
-          }
-        }
-      } yield (new CompactedConsumeResult[Key, Value](lastVals, compactedConsumeResult.nextOffsets, compactedConsumeResult.noOfConsumedMessages))
+          key.zip(value): IO[Option[Nothing], (Key, Option[Value])]
+        })
+      } yield (new CompactedConsumeResult[Key, Value](
+        lastVals.toMap,
+        compactedConsumeResult.nextOffsets,
+        compactedConsumeResult.noOfConsumedMessages
+      ))
 
     }
   }
@@ -75,32 +79,34 @@ object KafkaConsumerUtils {
   def consumeUntilEnd[Key, Value](
       consumer: Consumer,
       topicPartitions: List[TopicPartition],
-      keySerializer: Deserializer[Any, Key],
-      valueSerializer: Deserializer[Any, Value],
+      keyDeserializer: Deserializer[Any, Key],
+      valueDeserializer: Deserializer[Any, Value],
       pollTimeout: Duration = 100.millis
   ): Task[(Map[TopicPartition, Long], List[ConsumerRecord[Key, Value]])] = {
     val subscription = Manual(topicPartitions.toSet)
     for {
       endOffsets <- consumer.endOffsets(topicPartitions.toSet)
       partitionMapAndRecords <- consumer
-        .plainStream(subscription, keySerializer, valueSerializer)
+        .plainStream(subscription, keyDeserializer, valueDeserializer)
+        // This will ensure that the rest of this stream executes at least once
+        // prevents halting if the topic is empty.
         .aggregateAsyncWithin(ZSink.collectAll, Schedule.fixed(pollTimeout))
-        .mapZIO(record =>
-          ZIO.foreachPar(topicPartitions)(tp => consumer.position(tp).map(pos => (tp, pos))).map(nextOffsets => (record, nextOffsets.toMap))
+        // For all topic partitions, get the current position of the consumer.
+        .mapZIO(chunk =>
+          ZIO.foreachPar(topicPartitions)(tp => consumer.position(tp).map(pos => (tp, pos))).map(nextOffsets => (chunk, nextOffsets.toMap))
         )
+        // Check if there are any topic partitions that we haven't finished consuming.
         .takeUntil { (_, nextOffsets) =>
           !endOffsets.exists { case (tp, endOffset) => nextOffsets.get(tp).exists(nextOffset => nextOffset < endOffset) }
         }
         .map((records, _) => records)
         .runFold((mutable.Map.empty[TopicPartition, Long], mutable.ArrayBuffer.empty[ConsumerRecord[Key, Value]])) {
-          case ((nextTopicPartitionOffsets, records), newRecords) => {
+          case ((nextTopicPartitionOffsets, records), newRecords) =>
             for (newRecord <- newRecords) {
               nextTopicPartitionOffsets.update(new TopicPartition(newRecord.record.topic, newRecord.partition), newRecord.offset.offset + 1L)
               records.addOne(newRecord.record)
             }
-
             (nextTopicPartitionOffsets, records)
-          }
         }
 
       (partitionMap, records) = partitionMapAndRecords

--- a/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/persistence/KafkaPersistentStore.scala
+++ b/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/persistence/KafkaPersistentStore.scala
@@ -7,19 +7,21 @@
 package com.mwam.kafkakewl.common.persistence
 
 import com.mwam.kafkakewl.common.kafka.KafkaClientConfigExtensions.*
-import com.mwam.kafkakewl.common.kafka.KafkaConsumerExtensions.*
 import com.mwam.kafkakewl.common.kafka.AdminClientExtensions.*
 import com.mwam.kafkakewl.common.kafka.KafkaConsumerUtils
 import com.mwam.kafkakewl.domain.*
 import com.mwam.kafkakewl.domain.DeploymentsJson.given
 import com.mwam.kafkakewl.domain.config.KafkaClientConfig
-import org.apache.kafka.clients.consumer.Consumer
+import zio.kafka.consumer.Consumer
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import zio.*
 import zio.json.*
 import zio.kafka.producer.*
-import zio.kafka.serde.Serde
+import zio.kafka.consumer.*
+import zio.kafka.serde.{Deserializer, Serde}
 import zio.kafka.admin.*
+import zio.kafka.consumer.Consumer.AutoOffsetStrategy
 import zio.stream.*
 
 import scala.collection.mutable.ListBuffer
@@ -58,7 +60,11 @@ class KafkaPersistentStore(
     initializeIfNeeded *>
       ZIO.scoped {
         for {
-          consumer <- KafkaConsumerUtils.kafkaConsumerStringStringZIO(kafkaClientConfig)
+          consumer <- Consumer.make(
+            ConsumerSettings(kafkaClientConfig.brokersList, kafkaClientConfig.additionalConfig).withOffsetRetrieval(
+              Consumer.OffsetRetrieval.Auto(AutoOffsetStrategy.Earliest)
+            )
+          )
           _ <- ZIO.logInfo(s"loading the topologies from the $topicName kafka topic")
           deserializedTopologiesWithDuration <- consumeUntilEnd(consumer, topicName).timed
           (duration, deserializedTopologies) = deserializedTopologiesWithDuration
@@ -189,18 +195,30 @@ class KafkaPersistentStore(
     } yield ()
   }
 
-  private def consumeUntilEnd(consumer: Consumer[String, String], topic: String): Task[Map[TopologyId, Either[String, TopologyDeployment]]] =
-    ZIO.attempt {
-      val messages = new ListBuffer[(String, String)]()
-      val topicPartitions = consumer.topicPartitionsOf(topic)
-      // keeping the last TopologyDeployments only
-      KafkaConsumerUtils.consumeUntilEnd(consumer, topicPartitions) { _.forEach(cr => messages += (cr.key -> cr.value)) }
+  private def consumeUntilEnd(consumer: Consumer, topic: String): Task[Map[TopologyId, Either[String, TopologyDeployment]]] = {
 
-      messages
-        // Here we don't care about the message batch, just extract the payload
-        .map { case (key, value) => (TopologyId(key), value.fromJson[BatchMessageEnvelope[TopologyDeployment]].map(_.payload)) }.toMap
-    }
+    for {
+      topicPartitions <- consumer.partitionsFor(topic)
+      partitionMapAndRecords <- KafkaConsumerUtils.consumeUntilEnd(
+        consumer,
+        topicPartitions.map(tpi => new TopicPartition(tpi.topic(), tpi.partition())),
+        Deserializer.string,
+        Deserializer.string
+      )
+      (partitionMap, records) = partitionMapAndRecords
 
+      topologyMap = records
+        .foldLeft(collection.mutable.Map.empty[String, String]) {
+          case (map, record) => {
+            map.update(record.key(), record.value())
+            map
+          }
+        }
+        .map { case (key, value) => (TopologyId(key), value.fromJson[BatchMessageEnvelope[TopologyDeployment]].map(_.payload)) }
+        .toMap
+
+    } yield topologyMap
+  }
   private def topicConfig = kafkaPersistentStoreConfig.topic
   private def topicName = topicConfig.name
   private val defaultKafkaTopicConfig = Map(TopicConfig.RETENTION_MS_CONFIG -> "-1")

--- a/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/persistence/KafkaPersistentStore.scala
+++ b/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/persistence/KafkaPersistentStore.scala
@@ -24,8 +24,6 @@ import zio.kafka.admin.*
 import zio.kafka.consumer.Consumer.AutoOffsetStrategy
 import zio.stream.*
 
-import scala.collection.mutable.ListBuffer
-
 final case class BatchMessageEnvelope[Payload](
     batchSize: Int,
     indexInBatch: Int,

--- a/kafkakewl-common/src/test/resources/logback.xml
+++ b/kafkakewl-common/src/test/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] [%mdc] %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+    </appender>
+
+    <logger name="org.apache.kafka" level="ERROR" />
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="state.change.logger" level="ERROR" />
+    <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
+    <logger name="com.yammer.metrics" level="ERROR"/>
+    <logger name="kafka" level="ERROR" />
+
+    <!-- Some useful loggers to configure while debugging tests: -->
+    <logger name="zio.kafka" level="INFO" />
+    <logger name="zio.kafka.consumer.ConsumerSpec" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/kafkakewl-common/src/test/scala/KafkaConsumerUtilsTest.scala
+++ b/kafkakewl-common/src/test/scala/KafkaConsumerUtilsTest.scala
@@ -6,16 +6,26 @@
 
 import KafkaConsumerUtilsTest.test
 import com.mwam.kafkakewl.common.kafka.KafkaConsumerUtils
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import zio.*
-import zio.kafka.consumer.{Consumer}
-import zio.kafka.producer.{Producer}
-import zio.kafka.serde.{Deserializer}
-import zio.kafka.testkit.KafkaTestUtils.{consumer, produceMany, producer}
+import zio.kafka.consumer.{CommittableRecord, Consumer, ConsumerSettings, Subscription}
+import zio.kafka.producer.TransactionalProducer.UserInitiatedAbort
+import zio.kafka.producer.{Producer, TransactionalProducer}
+import zio.kafka.serde.{Deserializer, Serde}
+import zio.kafka.testkit.KafkaTestUtils.{consumer, produceMany, producer, transactionalConsumerSettings, transactionalProducer}
 import zio.kafka.testkit.*
+import zio.stream.Take
 import zio.test.*
 
 object KafkaConsumerUtilsTest extends ZIOSpecWithKafka with KafkaRandom {
+  def withConsumerInt(
+      subscription: Subscription,
+      settings: ConsumerSettings
+  ): ZIO[Any with Scope, Throwable, Dequeue[Take[Throwable, CommittableRecord[String, Int]]]] =
+    Consumer.make(settings).flatMap { c =>
+      c.plainStream(subscription, Serde.string, Serde.int).toQueue()
+    }
   override def kafkaPrefix: String = "consumer-spec"
 
   override def spec: Spec[TestEnvironment & Kafka & Scope, Any] =
@@ -64,14 +74,59 @@ object KafkaConsumerUtilsTest extends ZIOSpecWithKafka with KafkaRandom {
           _ <- ZIO.debug(s"Number of records: ${records.length}")
           _ <- ZIO.debug(s"Offsets: ${topicPartitionOffsets}")
         } yield assertTrue(records.length == 1000000, topicPartitionOffsets.values.sum >= 1000000L)
+      },
+      test("rolledback query") {
+
+        for {
+          topic <- randomTopic
+          group <- randomGroup
+          client <- randomClient
+          kvs = (1 to 100).toList.map(i => new ProducerRecord(topic, s"key-$i", s"msg-$i"))
+
+          _ <- ZIO.scoped {
+            TransactionalProducer.createTransaction.tap { t =>
+              ZIO.foreach(kvs.take(10))(t.produce(_, Serde.string, Serde.string, None))
+            }
+          }
+          _ <- ZIO
+            .scoped {
+              TransactionalProducer.createTransaction
+                .flatMap { t =>
+                  ZIO.foreachDiscard(kvs.take(50))(t.produce(_, Serde.string, Serde.string, None)) *> t.abort
+                }
+            }
+            .catchSome { case UserInitiatedAbort =>
+              ZIO.unit
+            }
+          _ <- ZIO.scoped {
+            TransactionalProducer.createTransaction.tap { t =>
+              ZIO.foreach(kvs.take(10))(t.produce(_, Serde.string, Serde.string, None))
+            }
+          }
+          recordsAndTpos <- ZIO.scoped {
+            for {
+              settings <- transactionalConsumerSettings(group, client)
+              cons <- Consumer.make(settings)
+              tps <- cons.partitionsFor(topic).map(tpis => tpis.map(tpi => new TopicPartition(tpi.topic(), tpi.partition())))
+
+              recordsAndTpos <- KafkaConsumerUtils
+                .consumeUntilEnd(cons, tps, Serde.string, Serde.string)
+
+            } yield recordsAndTpos
+          }
+
+          (topicPartitionOffsets, records) = recordsAndTpos
+          _ <- ZIO.debug(s"Number of records: ${records.length}")
+          _ <- ZIO.debug(s"Offsets: ${topicPartitionOffsets}")
+        } yield assertTrue(records.length == 20, topicPartitionOffsets.values.sum >= 70L)
+
       }
     )
       .provideSome[Kafka](
         producer,
         ZLayer.fromZIOEnvironment(randomClient.zip(randomGroup).flatMap((c, g) => consumer(c, Some(g)).build)),
-        Scope.default
-      )
-      .provideSomeShared(
+        Scope.default,
+        transactionalProducer,
         Kafka.embedded
       ) @@ TestAspect.withLiveClock
 

--- a/kafkakewl-common/src/test/scala/KafkaConsumerUtilsTest.scala
+++ b/kafkakewl-common/src/test/scala/KafkaConsumerUtilsTest.scala
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Marshall Wace <opensource@mwam.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import com.mwam.kafkakewl.common.kafka.KafkaConsumerUtils
+import org.apache.kafka.common.TopicPartition
+import zio.*
+import zio.kafka.consumer.{Consumer, ConsumerSettings}
+import zio.kafka.serde.{Deserializer}
+import zio.kafka.testkit.KafkaTestUtils.{consumerSettings, minimalConsumer, produceMany, producer}
+import zio.kafka.testkit.*
+import zio.test.*
+
+object KafkaConsumerUtilsTest extends ZIOSpecWithKafka with KafkaRandom {
+  override def kafkaPrefix: String = "consumer-spec"
+
+  override def spec: Spec[TestEnvironment & Kafka & Scope, Any] =
+    suite("KafkaConsumerUtils test suite")(
+      test("non-empty topic") {
+        val kvs: List[(String, String)] = (1 to 5).toList.map(i => (s"key-$i", s"msg-$i"))
+        for {
+          topic <- randomTopic
+          _ <- produceMany(topic, kvs)
+          cons <- ZIO.service[Consumer]
+          tps <- cons.partitionsFor(topic).map(tpis => tpis.map(tpi => new TopicPartition(tpi.topic(), tpi.partition())))
+
+          recordsAndTpos <- KafkaConsumerUtils
+            .consumeUntilEnd(cons, tps, Deserializer.string, Deserializer.string)
+
+          (_, records) = recordsAndTpos
+          _ <- ZIO.debug(s"Number of records: ${records.length}")
+        } yield assertTrue(records.length == 5)
+      },
+      test("empty topic") {
+        for {
+          topic <- randomTopic
+          cons <- ZIO.service[Consumer]
+          tps <- cons.partitionsFor(topic).map(tpis => tpis.map(tpi => new TopicPartition(tpi.topic(), tpi.partition())))
+
+          recordsAndTpos <- KafkaConsumerUtils
+            .consumeUntilEnd(cons, tps, Deserializer.string, Deserializer.string)
+
+          (_, records) = recordsAndTpos
+          _ <- ZIO.debug(s"Number of records: ${records.length}")
+        } yield assertTrue(records.isEmpty)
+      },
+      test("large topic") {
+        val kvs: List[(String, String)] = (1 to 1000000).toList.map(i => (s"key-$i", s"msg-$i"))
+        for {
+          topic <- randomTopic
+          _ <- produceMany(topic, kvs)
+          cons <- ZIO.service[Consumer]
+          tps <- cons.partitionsFor(topic).map(tpis => tpis.map(tpi => new TopicPartition(tpi.topic(), tpi.partition())))
+
+          recordsAndTpos <- KafkaConsumerUtils
+            .consumeUntilEnd(cons, tps, Deserializer.string, Deserializer.string)
+
+          (_, records) = recordsAndTpos
+          _ <- ZIO.debug(s"Number of records: ${records.length}")
+        } yield assertTrue(records.length == 1000000)
+      }
+    )
+      .provideSome[Kafka](
+        producer,
+        minimalConsumer(),
+        ZLayer.fromZIO(randomClient.zip(randomGroup).flatMap((c, g) => consumerSettings(c, Some(g))))
+      )
+      .provideSomeShared(
+        Kafka.embedded
+      ) @@ TestAspect.withLiveClock
+
+}

--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/services/TopologyDeploymentsService.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/services/TopologyDeploymentsService.scala
@@ -58,7 +58,6 @@ class TopologyDeploymentsService private (
       } yield DeploymentsSuccess(
         topologyDeployments
           .map((tid, td) => (tid, td.status))
-          .toMap
       )
     }
 

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/ConsumerOffsetsSource.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/ConsumerOffsetsSource.scala
@@ -206,9 +206,7 @@ object ConsumerOffsetsSource {
           }
 
         val zipped: IO[Throwable, Option[(ConsumerGroupTopicPartition, Option[KafkaConsumerGroupOffset])]] =
-          key
-            .zipWith(value)((key, value) => key.zip(Some(value)))
-            .orElseFail(new Throwable("fail"))
+          key.zipWith(value)((key, value) => key.zip(Some(value)))
 
         zipped
       }


### PR DESCRIPTION
Replaced all instances of the traditional Kafka consumer with ZIO's Kafka Consumer.
This comes with some benefits:
- Type safety in deserialization.
- Thread safety.
- No blocking a ZIO fibre on reading from Kafka.
- Cleaner, functional approach to reading from Kafka.

Some things of note:
- Regression from scala 3.3.1 and Java 21 to 3.3.0 and Java <21. This is because of a scala 3 compiler bug found in 3.3.1, which panics during type inference (a mundane usage of the type checker at that). Java 21 is not compatible with scala 3.3.0, so both must be regressed in tandem. After the release of scala 3.3.2, it should be okay to upgrade again. 