### PR TITLE
Add configurable timeouts to every api endpoint in deploy and metrics

### DIFF
--- a/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/http/EndpointUtils.scala
+++ b/kafkakewl-common/src/main/scala/com/mwam/kafkakewl/common/http/EndpointUtils.scala
@@ -6,8 +6,6 @@
 
 package com.mwam.kafkakewl.common.http
 
-import com.mwam.kafkakewl.domain.TimeoutException
-import com.mwam.kafkakewl.domain.config.Timeout
 import sttp.model.StatusCode
 import sttp.tapir.*
 import sttp.tapir.CodecFormat.TextPlain
@@ -38,8 +36,8 @@ object EndpointUtils {
     stringBodyUtf8AnyFormat(zioYamlCodec.mapDecode(jsonDecode.rawDecode)(jsonDecode.encode))
   }
 
-  def timeout[A, E, R, B, E1 >: E](f: A => ZIO[R, E1, B])(implicit timeout: Timeout, exception: TimeoutException[E]): A => ZIO[R, E1, B] = { a =>
-    f(a).timeoutFail(exception.exception)(Duration.fromSeconds(timeout.seconds))
+  def timeout[A, E, B, R](timeout: Duration, exception: E)(f: A => ZIO[Any, E, B]): A => ZIO[R, E, B] = { a =>
+    f(a).timeoutFail(exception)(timeout)
   }
 
   private val zioYamlCodec: Codec[String, String, TextPlain] =

--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/DeploymentsEndpoints.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/DeploymentsEndpoints.scala
@@ -15,7 +15,7 @@ import sttp.model.StatusCode
 import sttp.tapir.CodecFormat.TextPlain
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.zio.*
-import sttp.tapir.ztapir.*
+import sttp.tapir.ztapir.{oneOfVariant, *}
 import sttp.tapir.{Codec, CodecFormat, FieldName, PublicEndpoint, Schema, oneOf}
 import zio.*
 import zio.json.{JsonDecoder, JsonEncoder}
@@ -26,7 +26,8 @@ class DeploymentsEndpoints() extends EndpointUtils {
 
   private val queryDeploymentsFailureOutput = oneOf[QueryDeploymentsFailure](
     oneOfVariant(statusCode(StatusCode.NotFound).and(jsonBody[DeploymentsFailure.NotFound])),
-    oneOfVariant(statusCode(StatusCode.Unauthorized).and(jsonBody[DeploymentsFailure.Authorization]))
+    oneOfVariant(statusCode(StatusCode.Unauthorized).and(jsonBody[DeploymentsFailure.Authorization])),
+    oneOfVariant(statusCode(StatusCode.RequestTimeout).and(jsonBody[DeploymentsFailure.Timeout]))
   )
 
   val getDeploymentEndpoint: PublicEndpoint[TopologyId, QueryDeploymentsFailure, TopologyDeployment, Any] = deploymentEndpoint
@@ -53,7 +54,8 @@ class DeploymentsEndpoints() extends EndpointUtils {
         oneOfVariant(statusCode(StatusCode.Unauthorized).and(jsonBody[DeploymentsFailure.Authorization])),
         oneOfVariant(statusCode(StatusCode.UnprocessableEntity).and(jsonBody[DeploymentsFailure.Validation])),
         oneOfVariant(statusCode(StatusCode.InternalServerError).and(jsonBody[DeploymentsFailure.Deployment])),
-        oneOfVariant(statusCode(StatusCode.InternalServerError).and(jsonBody[DeploymentsFailure.Persistence]))
+        oneOfVariant(statusCode(StatusCode.InternalServerError).and(jsonBody[DeploymentsFailure.Persistence])),
+        oneOfVariant(statusCode(StatusCode.RequestTimeout).and(jsonBody[DeploymentsFailure.Timeout]))
       )
     )
     .out(jsonBody[DeploymentsSuccess])

--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
@@ -16,11 +16,7 @@ class Endpoints(
     deploymentServerEndpoints: DeploymentsServerEndpoints,
     prometheusPublisher: PrometheusPublisher
 ) {
-  private val metricsEndpoint: PublicEndpoint[Unit, Unit, String, Any] =
-    endpoint
-      .in("metrics")
-      .get
-      .out(stringBody)
+  private val metricsEndpoint: PublicEndpoint[Unit, Unit, String, Any] = endpoint.in("metrics").get.out(stringBody)
 
   // Health check endpoints. As of now, just return 200 no preparation is done
   // after the HTTP server starts.
@@ -49,11 +45,9 @@ class Endpoints(
     .fromServerEndpoints[Task](apiEndpoints, "kafkakewl-deploy", "1.0.0")
 
   // Regex to remove timestamp from the end of each metric. This is to fix the staleness issue in prometheus.
-  private def getMetrics: ZIO[Any, Unit, String] =
-    prometheusPublisher.get.map(_.replaceAll("[0-9]+\n", "\n"))
+  private def getMetrics: ZIO[Any, Unit, String] = prometheusPublisher.get.map(_.replaceAll("[0-9]+\n", "\n"))
 }
 
 object Endpoints {
-  val live: ZLayer[DeploymentsServerEndpoints & PrometheusPublisher, Nothing, Endpoints] =
-    ZLayer.fromFunction(Endpoints(_, _))
+  val live: ZLayer[DeploymentsServerEndpoints & PrometheusPublisher, Nothing, Endpoints] = ZLayer.fromFunction(Endpoints(_, _))
 }

--- a/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
+++ b/kafkakewl-deploy/src/main/scala/com/mwam/kafkakewl/deploy/endpoints/Endpoints.scala
@@ -6,19 +6,11 @@
 
 package com.mwam.kafkakewl.deploy.endpoints
 
-import com.mwam.kafkakewl.common.http.{EndpointUtils, ErrorResponse}
-//import com.mwam.kafkakewl.deploy.domain.{Failures, QueryFailure}
-import sttp.model.StatusCode
-import sttp.tapir.{EndpointOutput, PublicEndpoint}
+import sttp.tapir.PublicEndpoint
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
-//import sttp.tapir.ztapir.a
 import zio.*
-import sttp.tapir.generic.auto.*
-import sttp.tapir.json.zio.jsonBody
 import zio.metrics.connectors.prometheus.PrometheusPublisher
-
-import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
 class Endpoints(
     deploymentServerEndpoints: DeploymentsServerEndpoints,

--- a/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/Deployments.scala
+++ b/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/Deployments.scala
@@ -95,5 +95,3 @@ object DeploymentsFailure {
   *   the statuses of the topology deployments.
   */
 final case class DeploymentsSuccess(statuses: Map[TopologyId, TopologyDeploymentStatus])
-
-case class TimeoutException[E](exception: E)

--- a/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/Deployments.scala
+++ b/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/Deployments.scala
@@ -77,12 +77,14 @@ object DeploymentsFailure {
   final case class Validation(validationFailed: Seq[String]) extends PostDeploymentsFailure
   final case class Deployment(deploymentFailed: Seq[String]) extends PostDeploymentsFailure
   final case class Persistence(persistFailed: Seq[String]) extends PostDeploymentsFailure
+  final case class Timeout(timeout: String) extends PostDeploymentsFailure with QueryDeploymentsFailure
 
   def notFound(notFound: String*): NotFound = NotFound(notFound)
   def authorization(throwable: Throwable): Authorization = Authorization(errors(throwable))
   def validation(errors: NonEmptyChunk[String]): Validation = Validation(errors)
   def deployment(throwable: Throwable): Deployment = Deployment(errors(throwable))
   def persistence(throwable: Throwable): Persistence = Persistence(errors(throwable))
+  def timeout: Timeout = Timeout("Request timed out. Please try again later.")
 
   private def errors(throwable: Throwable): Seq[String] = Seq(throwable.getMessage)
 }
@@ -93,3 +95,5 @@ object DeploymentsFailure {
   *   the statuses of the topology deployments.
   */
 final case class DeploymentsSuccess(statuses: Map[TopologyId, TopologyDeploymentStatus])
+
+case class TimeoutException[E](exception: E)

--- a/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/DeploymentsJson.scala
+++ b/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/DeploymentsJson.scala
@@ -31,4 +31,6 @@ object DeploymentsJson {
   given JsonDecoder[DeploymentsFailure.Deployment] = DeriveJsonDecoder.gen[DeploymentsFailure.Deployment]
   given JsonEncoder[DeploymentsFailure.Persistence] = DeriveJsonEncoder.gen[DeploymentsFailure.Persistence]
   given JsonDecoder[DeploymentsFailure.Persistence] = DeriveJsonDecoder.gen[DeploymentsFailure.Persistence]
+  given JsonEncoder[DeploymentsFailure.Timeout] = DeriveJsonEncoder.gen[DeploymentsFailure.Timeout]
+  given JsonDecoder[DeploymentsFailure.Timeout] = DeriveJsonDecoder.gen[DeploymentsFailure.Timeout]
 }

--- a/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/config/HttpConfig.scala
+++ b/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/config/HttpConfig.scala
@@ -12,5 +12,3 @@ final case class HttpConfig(
     port: Int = 8080,
     timeout: Duration = Duration.fromSeconds(10)
 )
-
-case class Timeout(seconds: Int)

--- a/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/config/HttpConfig.scala
+++ b/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/config/HttpConfig.scala
@@ -7,5 +7,8 @@
 package com.mwam.kafkakewl.domain.config
 
 final case class HttpConfig(
-    port: Int = 8080
+    port: Int = 8080,
+    timeout: Timeout = Timeout(10)
 )
+
+case class Timeout(seconds: Int)

--- a/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/config/HttpConfig.scala
+++ b/kafkakewl-domain/src/main/scala/com/mwam/kafkakewl/domain/config/HttpConfig.scala
@@ -6,9 +6,11 @@
 
 package com.mwam.kafkakewl.domain.config
 
+import zio.Duration
+
 final case class HttpConfig(
     port: Int = 8080,
-    timeout: Timeout = Timeout(10)
+    timeout: Duration = Duration.fromSeconds(10)
 )
 
 case class Timeout(seconds: Int)

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/Failures.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/Failures.scala
@@ -13,9 +13,11 @@ sealed trait QueryFailure
 object Failures {
   final case class NotFound(notFound: Seq[String]) extends QueryFailure
   final case class Authorization(authorizationFailed: Seq[String]) extends QueryFailure
+  final case class Timeout(timeout: String) extends QueryFailure
 
   def notFound(notFound: String*): NotFound = NotFound(notFound)
   def authorization(throwable: Throwable): Authorization = Authorization(errors(throwable))
+  def timeout: Timeout = Timeout("Request timed out. Please try again later.")
 
   private def errors(throwable: Throwable): Seq[String] = Seq(throwable.getMessage)
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/FailuresJson.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/FailuresJson.scala
@@ -13,4 +13,8 @@ object FailuresJson {
   given JsonDecoder[Failures.NotFound] = DeriveJsonDecoder.gen[Failures.NotFound]
   given JsonEncoder[Failures.Authorization] = DeriveJsonEncoder.gen[Failures.Authorization]
   given JsonDecoder[Failures.Authorization] = DeriveJsonDecoder.gen[Failures.Authorization]
+
+  given JsonEncoder[Failures.Timeout] = DeriveJsonEncoder.gen[Failures.Timeout]
+
+  given JsonDecoder[Failures.Timeout] = DeriveJsonDecoder.gen[Failures.Timeout]
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/ConsumerGroupServerEndpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/ConsumerGroupServerEndpoints.scala
@@ -22,7 +22,7 @@ class ConsumerGroupServerEndpoints(
 
   val endpoints: List[ZServerEndpoint[Any, Any]] = List(
     consumerGroupEndpoints.getGroupsEndpoint.zServerLogicWithTracing(_ => getConsumerGroups),
-    consumerGroupEndpoints.getGroupEndpoint.zServerLogicWithTracing(group => getConsumerGroup(group))
+    consumerGroupEndpoints.getGroupEndpoint.zServerLogicWithTracing(getConsumerGroup)
   )
 
   private def getConsumerGroups: ZIO[Any, QueryFailure, Seq[String]] = consumerGroupInfoCache.getConsumerGroups

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/EndpointOutputs.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/EndpointOutputs.scala
@@ -17,6 +17,7 @@ import sttp.tapir.ztapir.*
 trait EndpointOutputs {
   val queryFailureOutput: EndpointOutput.OneOf[QueryFailure, QueryFailure] = oneOf[QueryFailure](
     oneOfVariant(statusCode(StatusCode.NotFound).and(jsonBody[Failures.NotFound])),
-    oneOfVariant(statusCode(StatusCode.Unauthorized).and(jsonBody[Failures.Authorization]))
+    oneOfVariant(statusCode(StatusCode.Unauthorized).and(jsonBody[Failures.Authorization])),
+    oneOfVariant(statusCode(StatusCode.RequestTimeout).and(jsonBody[Failures.Timeout]))
   )
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/TopicServerEndpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/TopicServerEndpoints.scala
@@ -9,23 +9,22 @@ package com.mwam.kafkakewl.metrics.endpoints
 import com.mwam.kafkakewl.common.http.EndpointUtils
 import com.mwam.kafkakewl.common.http.EndpointUtils.timeout
 import com.mwam.kafkakewl.common.telemetry.zServerLogicWithTracing
-import com.mwam.kafkakewl.domain.{TimeoutException, config}
+import com.mwam.kafkakewl.domain.config.HttpConfig
+import com.mwam.kafkakewl.domain.config
 import com.mwam.kafkakewl.metrics.domain.{Failures, KafkaSingleTopicPartitionInfos, QueryFailure}
 import com.mwam.kafkakewl.metrics.services.KafkaTopicInfoCache
-import com.mwam.kafkakewl.metrics.MainConfig
 import sttp.tapir.ztapir.*
 import zio.*
 import zio.telemetry.opentelemetry.tracing.Tracing
 
-class TopicServerEndpoints(topicEndpoints: TopicEndpoints, topicService: KafkaTopicInfoCache, tracing: Tracing, mainConfig: MainConfig) {
+class TopicServerEndpoints(topicEndpoints: TopicEndpoints, topicService: KafkaTopicInfoCache, tracing: Tracing, httpConfig: HttpConfig) {
   given Tracing = tracing
 
-  implicit val timeout: config.Timeout = mainConfig.http.timeout
-  implicit val timeoutException: TimeoutException[Failures.Timeout] = TimeoutException(Failures.timeout)
+  private def timeout[A, B, E >: Failures.Timeout] = EndpointUtils.timeout[A, E, B, Any](httpConfig.timeout, Failures.timeout)
 
   val endpoints: List[ZServerEndpoint[Any, Any]] = List(
-    topicEndpoints.getTopicsEndpoint.zServerLogicWithTracing(EndpointUtils.timeout(_ => getTopics)),
-    topicEndpoints.getTopicEndpoint.zServerLogicWithTracing(EndpointUtils.timeout(getTopic))
+    topicEndpoints.getTopicsEndpoint.zServerLogicWithTracing(timeout(_ => getTopics)),
+    topicEndpoints.getTopicEndpoint.zServerLogicWithTracing(timeout(getTopic))
   )
 
   private def getTopics: ZIO[Any, QueryFailure, Seq[String]] = topicService.getTopics
@@ -43,6 +42,6 @@ class TopicServerEndpoints(topicEndpoints: TopicEndpoints, topicService: KafkaTo
 }
 
 object TopicServerEndpoints {
-  val live: ZLayer[TopicEndpoints & KafkaTopicInfoCache & Tracing & MainConfig, Nothing, TopicServerEndpoints] =
+  val live: ZLayer[TopicEndpoints & KafkaTopicInfoCache & Tracing & HttpConfig, Nothing, TopicServerEndpoints] =
     ZLayer.fromFunction(TopicServerEndpoints(_, _, _, _))
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/TopicServerEndpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/TopicServerEndpoints.scala
@@ -6,19 +6,26 @@
 
 package com.mwam.kafkakewl.metrics.endpoints
 
+import com.mwam.kafkakewl.common.http.EndpointUtils
+import com.mwam.kafkakewl.common.http.EndpointUtils.timeout
 import com.mwam.kafkakewl.common.telemetry.zServerLogicWithTracing
+import com.mwam.kafkakewl.domain.{TimeoutException, config}
 import com.mwam.kafkakewl.metrics.domain.{Failures, KafkaSingleTopicPartitionInfos, QueryFailure}
 import com.mwam.kafkakewl.metrics.services.KafkaTopicInfoCache
+import com.mwam.kafkakewl.metrics.MainConfig
 import sttp.tapir.ztapir.*
 import zio.*
 import zio.telemetry.opentelemetry.tracing.Tracing
 
-class TopicServerEndpoints(topicEndpoints: TopicEndpoints, topicService: KafkaTopicInfoCache, tracing: Tracing) {
+class TopicServerEndpoints(topicEndpoints: TopicEndpoints, topicService: KafkaTopicInfoCache, tracing: Tracing, mainConfig: MainConfig) {
   given Tracing = tracing
 
+  implicit val timeout: config.Timeout = mainConfig.http.timeout
+  implicit val timeoutException: TimeoutException[Failures.Timeout] = TimeoutException(Failures.timeout)
+
   val endpoints: List[ZServerEndpoint[Any, Any]] = List(
-    topicEndpoints.getTopicsEndpoint.zServerLogicWithTracing(_ => getTopics),
-    topicEndpoints.getTopicEndpoint.zServerLogicWithTracing(topic => getTopic(topic))
+    topicEndpoints.getTopicsEndpoint.zServerLogicWithTracing(EndpointUtils.timeout(_ => getTopics)),
+    topicEndpoints.getTopicEndpoint.zServerLogicWithTracing(EndpointUtils.timeout(getTopic))
   )
 
   private def getTopics: ZIO[Any, QueryFailure, Seq[String]] = topicService.getTopics
@@ -36,6 +43,6 @@ class TopicServerEndpoints(topicEndpoints: TopicEndpoints, topicService: KafkaTo
 }
 
 object TopicServerEndpoints {
-  val live: ZLayer[TopicEndpoints & KafkaTopicInfoCache & Tracing, Nothing, TopicServerEndpoints] =
-    ZLayer.fromFunction(TopicServerEndpoints(_, _, _))
+  val live: ZLayer[TopicEndpoints & KafkaTopicInfoCache & Tracing & MainConfig, Nothing, TopicServerEndpoints] =
+    ZLayer.fromFunction(TopicServerEndpoints(_, _, _, _))
 }


### PR DESCRIPTION
These wrapping each endpoint in a timeout. Lengths for the timeout are configurable on start-up.