### PR TITLE
Made skeleton for calculating consumer group metrics

### DIFF
--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/Main.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/Main.scala
@@ -58,6 +58,8 @@ object Main extends ZIOAppDefault {
       topicInfoSource <- ZIO.service[KafkaTopicInfoSource]
       _ <- topicInfoSource.startPublishing()
       consumerOffsetsSource <- ZIO.service[ConsumerOffsetsSource]
+      consumerCalcSource <- ZIO.service[KafkaConsumerGroupMetricsCalc]
+      _ <- consumerCalcSource.startPublishing()
       _ <- consumerOffsetsSource.startPublishing()
 
       endpoints <- ZIO.service[Endpoints]
@@ -79,6 +81,7 @@ object Main extends ZIOAppDefault {
       ConsumerOffsetsSource.live,
       KafkaTopicInfoSource.live,
       KafkaTopicInfoCache.live,
+      KafkaConsumerGroupMetricsCalc.live,
       KafkaConsumerGroupInfoCache.live,
       TopicEndpoints.live,
       TopicServerEndpoints.live,

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfo.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfo.scala
@@ -9,32 +9,13 @@ package com.mwam.kafkakewl.metrics.domain
 import scala.collection.immutable.SortedMap
 
 final case class KafkaConsumerGroupInfo(
-    topics: Map[String, SortedMap[Int, KafkaConsumerGroupOffset]]
+    topics: SortedMap[String, KafkaConsumerGroupTopicInfo]
+)
+
+final case class KafkaConsumerGroupTopicInfo(
+    partitions: SortedMap[Int, KafkaConsumerGroupMetrics]
 )
 
 object KafkaConsumerGroupInfo {
-  val empty: KafkaConsumerGroupInfo = KafkaConsumerGroupInfo(Map.empty)
-}
-
-object KafkaConsumerGroupInfoExtensions {
-  extension (consumerGroupInfos: Map[String, KafkaConsumerGroupInfo]) {
-    def applyChanges(consumerGroupOffsets: KafkaConsumerGroupOffsets): Map[String, KafkaConsumerGroupInfo] = {
-      // TODO may not be very efficient, but works.
-      consumerGroupOffsets.foldLeft(consumerGroupInfos) { case (newConsumerGroupInfos, (cgtp, cgo)) =>
-        val group = cgtp.group
-        val topic = cgtp.topicPartition.topic
-        val partition = cgtp.topicPartition.partition
-
-        val currentConsumerGroupInfo = consumerGroupInfos.getOrElse(group, KafkaConsumerGroupInfo.empty)
-        val currentConsumerGroupTopic = currentConsumerGroupInfo.topics.getOrElse(topic, SortedMap.empty[Int, KafkaConsumerGroupOffset])
-
-        val newConsumerGroupTopic = cgo match {
-          case Some(consumerGroupOffset) => currentConsumerGroupTopic + (partition -> consumerGroupOffset)
-          case None                      => currentConsumerGroupTopic - partition
-        }
-        val newConsumerGroupInfo = KafkaConsumerGroupInfo(currentConsumerGroupInfo.topics + (topic -> newConsumerGroupTopic))
-        newConsumerGroupInfos + (cgtp.group -> newConsumerGroupInfo)
-      }
-    }
-  }
+  val empty: KafkaConsumerGroupInfo = KafkaConsumerGroupInfo(SortedMap.empty)
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfoJson.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfoJson.scala
@@ -9,12 +9,23 @@ package com.mwam.kafkakewl.metrics.domain
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder}
 
 import scala.collection.immutable.{Map, SortedMap}
+import KafkaTopicPartitionInfoJson.given
 
 object KafkaConsumerGroupInfoJson {
   given JsonEncoder[KafkaConsumerGroupOffset] = DeriveJsonEncoder.gen[KafkaConsumerGroupOffset]
   given JsonDecoder[KafkaConsumerGroupOffset] = DeriveJsonDecoder.gen[KafkaConsumerGroupOffset]
+  given JsonEncoder[ConsumerGroupStatus] = DeriveJsonEncoder.gen[ConsumerGroupStatus]
+  given JsonDecoder[ConsumerGroupStatus] = DeriveJsonDecoder.gen[ConsumerGroupStatus]
+  given JsonEncoder[KafkaConsumerGroupMetrics] = DeriveJsonEncoder.gen[KafkaConsumerGroupMetrics]
+  given JsonDecoder[KafkaConsumerGroupMetrics] = DeriveJsonDecoder.gen[KafkaConsumerGroupMetrics]
+  given kafkaConsumerGroupTopicInfoMapEncoder: JsonEncoder[SortedMap[Int, KafkaConsumerGroupMetrics]] =
+    JsonEncoder[Map[Int, KafkaConsumerGroupMetrics]].contramap(_.unsorted)
+  given kafkaConsumerGroupTopicInfoMapDecoder: JsonDecoder[SortedMap[Int, KafkaConsumerGroupMetrics]] =
+    JsonDecoder[Map[Int, KafkaConsumerGroupMetrics]].map(SortedMap.from)
+  given JsonEncoder[KafkaConsumerGroupTopicInfo] = DeriveJsonEncoder.gen[KafkaConsumerGroupTopicInfo]
+  given JsonDecoder[KafkaConsumerGroupTopicInfo] = DeriveJsonDecoder.gen[KafkaConsumerGroupTopicInfo]
+  given JsonEncoder[SortedMap[String, KafkaConsumerGroupTopicInfo]] = JsonEncoder[Map[String, KafkaConsumerGroupTopicInfo]].contramap(_.unsorted)
+  given JsonDecoder[SortedMap[String, KafkaConsumerGroupTopicInfo]] = JsonDecoder[Map[String, KafkaConsumerGroupTopicInfo]].map(SortedMap.from)
   given JsonEncoder[KafkaConsumerGroupInfo] = DeriveJsonEncoder.gen[KafkaConsumerGroupInfo]
   given JsonDecoder[KafkaConsumerGroupInfo] = DeriveJsonDecoder.gen[KafkaConsumerGroupInfo]
-  given JsonEncoder[SortedMap[Int, KafkaConsumerGroupOffset]] = JsonEncoder[Map[Int, KafkaConsumerGroupOffset]].contramap(_.toMap)
-  given JsonDecoder[SortedMap[Int, KafkaConsumerGroupOffset]] = JsonDecoder[Map[Int, KafkaConsumerGroupOffset]].map(SortedMap.from)
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfoJson.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfoJson.scala
@@ -14,8 +14,17 @@ import KafkaTopicPartitionInfoJson.given
 object KafkaConsumerGroupInfoJson {
   given JsonEncoder[KafkaConsumerGroupOffset] = DeriveJsonEncoder.gen[KafkaConsumerGroupOffset]
   given JsonDecoder[KafkaConsumerGroupOffset] = DeriveJsonDecoder.gen[KafkaConsumerGroupOffset]
-  given JsonEncoder[ConsumerGroupStatus] = DeriveJsonEncoder.gen[ConsumerGroupStatus]
-  given JsonDecoder[ConsumerGroupStatus] = DeriveJsonDecoder.gen[ConsumerGroupStatus]
+  given JsonEncoder[ConsumerGroupStatus] = JsonEncoder[String].contramap(_.toString)
+  // TODO: Is there a better way of decoding enum variants
+  given JsonDecoder[ConsumerGroupStatus] = JsonDecoder[String].mapOrFail {
+    case "Ok"           => Right(ConsumerGroupStatus.Ok)
+    case "Warning"      => Right(ConsumerGroupStatus.Warning)
+    case "Error"        => Right(ConsumerGroupStatus.Error)
+    case "Unknown"      => Right(ConsumerGroupStatus.Unknown)
+    case "MaybeStopped" => Right(ConsumerGroupStatus.MaybeStopped)
+    case "Stopped"      => Right(ConsumerGroupStatus.Stopped)
+    case other          => Left(s"Unknown enumeration value `$other` found")
+  }
   given JsonEncoder[KafkaConsumerGroupMetrics] = DeriveJsonEncoder.gen[KafkaConsumerGroupMetrics]
   given JsonDecoder[KafkaConsumerGroupMetrics] = DeriveJsonDecoder.gen[KafkaConsumerGroupMetrics]
   given kafkaConsumerGroupTopicInfoMapEncoder: JsonEncoder[SortedMap[Int, KafkaConsumerGroupMetrics]] =

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfoSchema.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupInfoSchema.scala
@@ -14,6 +14,8 @@ import scala.collection.immutable.SortedMap
 object KafkaConsumerGroupInfoSchema {
   given Schema[KafkaConsumerGroupInfo] = Schema.derived[KafkaConsumerGroupInfo]
   // TODO hmmm... this looks nasty, any better way of doing this?
-  given Schema[SortedMap[Int, KafkaConsumerGroupOffset]] =
-    Schema.schemaForMap[Int, KafkaConsumerGroupOffset](_.toString).map(a => Some(SortedMap.from(a)))(_.toMap)
+  given kafkaConsumerGroupTopicInfoMap: Schema[SortedMap[Int, KafkaConsumerGroupMetrics]] =
+    Schema.schemaForMap[Int, KafkaConsumerGroupMetrics](_.toString).map(a => Some(SortedMap.from(a)))(_.toMap)
+  given Schema[SortedMap[String, KafkaConsumerGroupTopicInfo]] =
+    Schema.schemaForMap[String, KafkaConsumerGroupTopicInfo](_.toString).map(a => Some(SortedMap.from(a)))(_.toMap)
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupMetrics.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/domain/KafkaConsumerGroupMetrics.scala
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Marshall Wace <opensource@mwam.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.mwam.kafkakewl.metrics.domain
+
+enum ConsumerGroupStatus(val severity: Int):
+  /** Aggregates 2 ConsumerGroupStatuses so that the result is the more severe.
+    */
+  def +(other: ConsumerGroupStatus): ConsumerGroupStatus = if (severity < other.severity) other else this
+
+  case Ok extends ConsumerGroupStatus(1)
+  case Unknown extends ConsumerGroupStatus(2)
+  case Warning extends ConsumerGroupStatus(3)
+  case Error extends ConsumerGroupStatus(4)
+  case MaybeStopped extends ConsumerGroupStatus(5)
+  case Stopped extends ConsumerGroupStatus(6)
+
+end ConsumerGroupStatus
+
+implicit class ConsumerGroupStatusIterableExtensions(consumerGroupStatuses: Iterable[ConsumerGroupStatus]) {
+  def combine: ConsumerGroupStatus = consumerGroupStatuses.fold(ConsumerGroupStatus.Ok)(_ + _)
+}
+
+final case class AggregatedConsumerGroupStatus(
+    best: ConsumerGroupStatus,
+    worst: ConsumerGroupStatus
+) {
+  def +(other: AggregatedConsumerGroupStatus) =
+    AggregatedConsumerGroupStatus(
+      if (other.best.severity < best.severity) other.best else best,
+      if (other.worst.severity > worst.severity) other.worst else worst
+    )
+}
+
+object AggregatedConsumerGroupStatus {
+  def apply(consumerGroupStatus: ConsumerGroupStatus) = new AggregatedConsumerGroupStatus(consumerGroupStatus, consumerGroupStatus)
+
+  val Ok = AggregatedConsumerGroupStatus(ConsumerGroupStatus.Ok)
+
+  implicit class AggregatedConsumerGroupStatusIterableExtensions(aggregatedConsumerGroupStatuses: Iterable[AggregatedConsumerGroupStatus]) {
+    def combine: Option[AggregatedConsumerGroupStatus] = aggregatedConsumerGroupStatuses.reduceOption(_ + _)
+  }
+}
+
+final case class KafkaConsumerGroupMetrics(
+    status: ConsumerGroupStatus,
+    partitionHigh: Option[KafkaTopicPartitionInfo],
+    committed: Option[KafkaConsumerGroupOffset],
+    lag: Option[Long],
+    consumedPerSecond: Option[Double]
+)
+
+object KafkaConsumerGroupMetrics {
+  implicit class ConsumerGroupMetricsExtensions(consumerGroupMetrics: Iterable[KafkaConsumerGroupMetrics]) {
+
+    /** Calculates the total lag. It's None if ALL partition lags are None, otherwise None lags are considered 0 and the others are added up.
+      */
+    def sumLag: Option[Long] = if (consumerGroupMetrics.exists(_.lag.isDefined)) Some(consumerGroupMetrics.map(_.lag.getOrElse(0L)).sum) else None
+
+    def combineStatus: ConsumerGroupStatus = consumerGroupMetrics.map(_.status).combine
+
+    def combineStatusAggregated: Option[AggregatedConsumerGroupStatus] =
+      consumerGroupMetrics.map(m => AggregatedConsumerGroupStatus(m.status)).combine
+
+    def sumConsumptionRate: Option[Double] =
+      if (consumerGroupMetrics.exists(_.consumedPerSecond.isDefined)) Some(consumerGroupMetrics.flatMap(_.consumedPerSecond).sum) else None
+  }
+}

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/ConsumerGroupServerEndpoints.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/endpoints/ConsumerGroupServerEndpoints.scala
@@ -30,7 +30,7 @@ class ConsumerGroupServerEndpoints(
   private def getConsumerGroup(consumerGroup: String): ZIO[Any, QueryFailure, KafkaConsumerGroupInfo] = for {
     _ <- tracing.addEvent("reading consumer group info from cache")
     _ <- tracing.setAttribute("group", consumerGroup)
-    consumerGroupInfo <- consumerGroupInfoCache.getConsumerGroupInfo(consumerGroup)
+    consumerGroupInfo <- consumerGroupInfoCache.getConsumerGroupMetrics(consumerGroup)
     _ <- tracing.addEvent(consumerGroupInfo match
       case Some(_) => "read consumer group info from cache"
       case None    => "consumer group not found in cache"

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupInfoCache.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupInfoCache.scala
@@ -6,34 +6,136 @@
 
 package com.mwam.kafkakewl.metrics.services
 
-import com.mwam.kafkakewl.metrics.domain.KafkaConsumerGroupInfoExtensions.*
-import com.mwam.kafkakewl.metrics.domain.{KafkaConsumerGroupInfo, KafkaConsumerGroupOffsets}
+import com.mwam.kafkakewl.metrics.domain.{KafkaConsumerGroupMetrics, KafkaConsumerGroupInfo, KafkaConsumerGroupTopicInfo}
 import zio.*
 
+import scala.collection.immutable.SortedMap
+
 class KafkaConsumerGroupInfoCache(
-    private val consumerGroupInfosRef: Ref[Map[String, KafkaConsumerGroupInfo]]
+    private val consumerGroupsMetricsByGroupByPartitionRef: Ref[Map[String, KafkaConsumerGroupInfo]]
 ) {
-  def getConsumerGroups: UIO[Seq[String]] = consumerGroupInfosRef.get.map(_.keys.toSeq.sorted)
-  def getConsumerGroupInfo(consumerGroup: String): UIO[Option[KafkaConsumerGroupInfo]] = consumerGroupInfosRef.get.map(_.get(consumerGroup))
+  def getConsumerGroups: UIO[Seq[String]] = consumerGroupsMetricsByGroupByPartitionRef.get.map(_.keys.toSeq)
+
+  def getConsumerGroupMetrics(consumerGroup: String): UIO[Option[KafkaConsumerGroupInfo]] =
+    consumerGroupsMetricsByGroupByPartitionRef.get.map(_.get(consumerGroup))
+
+  def getConsumerGroupTopicMetrics(consumerGroup: String, topic: String): UIO[Option[KafkaConsumerGroupTopicInfo]] =
+    consumerGroupsMetricsByGroupByPartitionRef.get.map(_.get(consumerGroup).flatMap(_.topics.get(topic)))
+
+  def getConsumerGroupsMetrics(consumerGroups: Iterable[String]): UIO[Map[String, Option[KafkaConsumerGroupInfo]]] =
+    consumerGroupsMetricsByGroupByPartitionRef.get.map(consumerGroupsMetricsByGroup =>
+      consumerGroups.map(group => (group, consumerGroupsMetricsByGroup.get(group))).toMap
+    )
 }
 
 object KafkaConsumerGroupInfoCache {
-  def live: ZLayer[ConsumerOffsetsSource, Nothing, KafkaConsumerGroupInfoCache] =
+  def live: ZLayer[KafkaConsumerGroupMetricsCalc, Nothing, KafkaConsumerGroupInfoCache] =
     ZLayer.scoped {
       for {
-        consumerGroupOffsetsDequeue <- ZIO.serviceWithZIO[ConsumerOffsetsSource](_.subscribe())
-        consumerGroupInfosRef <- Ref.make(Map.empty[String, KafkaConsumerGroupInfo])
-        processConsumerGroupOffsetsFiber <- processConsumerGroupOffsets(consumerGroupOffsetsDequeue, consumerGroupInfosRef).forever.fork
-        _ <- ZIO.addFinalizer(processConsumerGroupOffsetsFiber.interrupt)
-      } yield KafkaConsumerGroupInfoCache(consumerGroupInfosRef)
+        metricChangesDequeue <- ZIO.serviceWithZIO[KafkaConsumerGroupMetricsCalc](_.subscribe())
+        consumerGroupsMetricsByGroupByPartitionRef <- Ref.make(Map.empty[String, KafkaConsumerGroupInfo])
+        processMetricChangesFiber <- processMetricChanges(
+          metricChangesDequeue,
+          consumerGroupsMetricsByGroupByPartitionRef
+        ).forever.fork
+        _ <- ZIO.addFinalizer(processMetricChangesFiber.interrupt)
+      } yield KafkaConsumerGroupInfoCache(consumerGroupsMetricsByGroupByPartitionRef)
     }
 
-  private def processConsumerGroupOffsets(
-      consumerGroupOffsetsDequeue: Dequeue[KafkaConsumerGroupOffsets],
-      consumerGroupInfosRef: Ref[Map[String, KafkaConsumerGroupInfo]]
+  private def processMetricChanges(
+      metricChangesDequeue: Dequeue[KafkaConsumerGroupMetricChanges],
+      consumerGroupsMetricsByGroupByPartitionRef: Ref[Map[String, KafkaConsumerGroupInfo]]
   ) = for {
-    consumerGroupOffsets <- consumerGroupOffsetsDequeue.take
-    _ <- consumerGroupInfosRef.update(_.applyChanges(consumerGroupOffsets))
-    _ <- ZIO.logInfo(s"applied ${consumerGroupOffsets.size} consumer group topic partition offsets")
+    consumerGroupMetricChanges <- metricChangesDequeue.take
+
+    // We nest the updates to be the structure Group -> Topic -> Partition -> KafkaConsumerGroupMetrics
+    addedConsumerGroupMetricChangesGrouped = consumerGroupMetricChanges.addedOrUpdated
+      .groupBy((consumerGroupTopicPartition, _) => consumerGroupTopicPartition.group)
+      .map { (group, groupMetrics) =>
+        val topicMap = KafkaConsumerGroupInfo(
+          SortedMap.from(
+            groupMetrics
+              .groupBy((consumerGroupTopicPartition, _) => consumerGroupTopicPartition.topicPartition.topic)
+              .map { (topic, groupMetrics) =>
+                val value = KafkaConsumerGroupTopicInfo(
+                  SortedMap.from(groupMetrics.map((partition, groupMetrics) => (partition.topicPartition.partition, groupMetrics)))
+                )
+                (topic, value)
+              }
+          )
+        )
+        (group, topicMap)
+      }
+
+    // We nest the removals to be the structure Group -> Topic -> Set[Partition]
+    removedConsumerGroupMetricChangesGrouped = consumerGroupMetricChanges.removed
+      .groupBy(consumerGroupTopicPartition => consumerGroupTopicPartition.group)
+      .map { (group, groupMetrics) =>
+        val topicMap = SortedMap.from(
+          groupMetrics
+            .groupBy(consumerGroupTopicPartition => consumerGroupTopicPartition.topicPartition.topic)
+            .map((topic, partition) => (topic, partition.map(_.topicPartition.partition)))
+        )
+        (group, topicMap)
+      }
+    _ <- consumerGroupsMetricsByGroupByPartitionRef.update { oldMap =>
+      deepMergeRemove(deepMergeAdd(oldMap, addedConsumerGroupMetricChangesGrouped), removedConsumerGroupMetricChangesGrouped)
+    }
   } yield ()
+
+  private def deepMergeAdd(
+      metricMap: Map[String, KafkaConsumerGroupInfo],
+      addedOrUpdated: Map[String, KafkaConsumerGroupInfo]
+  ): Map[String, KafkaConsumerGroupInfo] = {
+    metricMap.keySet
+      .union(addedOrUpdated.keySet)
+      .map(group =>
+        val newTopicMap = (metricMap.get(group), addedOrUpdated.get(group)) match {
+          case (Some(oldTopicMap), Some(newTopicMap)) =>
+            val tmp = oldTopicMap.topics.keySet.unsorted
+              .union(newTopicMap.topics.keySet.unsorted)
+              .map(topic =>
+                val newPartitionMap = (oldTopicMap.topics.get(topic), newTopicMap.topics.get(topic)) match {
+                  case (Some(oldTopicMap), Some(newTopicMap)) => oldTopicMap.partitions ++ newTopicMap.partitions
+                  case (oldPartitionMap, newPartitionMap)     => oldPartitionMap.map(_.partitions).orElse(newPartitionMap.map(_.partitions)).get
+                }
+                (topic, KafkaConsumerGroupTopicInfo(newPartitionMap))
+              )
+            SortedMap.from(tmp)
+          case (oldTopicMap, newTopicMap) => oldTopicMap.map(_.topics).orElse(newTopicMap.map(_.topics)).get
+        }
+        (group, KafkaConsumerGroupInfo(newTopicMap))
+      )
+      .toMap
+  }
+
+  private def deepMergeRemove(
+      metricMap: Map[String, KafkaConsumerGroupInfo],
+      removed: Map[String, SortedMap[String, Set[Int]]]
+  ): Map[String, KafkaConsumerGroupInfo] = {
+    metricMap.keySet
+      .union(removed.keySet)
+      .map(group =>
+        val newTopicMap = (metricMap.get(group), removed.get(group)) match {
+          case (Some(oldTopicMap), Some(removedTopicMap)) =>
+            val tmp = oldTopicMap.topics.keySet.unsorted
+              .union(removedTopicMap.keySet)
+              .map(topic =>
+                val newPartitionMap = (oldTopicMap.topics.get(topic), removedTopicMap.get(topic)) match {
+                  case (Some(oldPartitionMap), Some(removedPartitionSet)) => oldPartitionMap.partitions.removedAll(removedPartitionSet)
+                  case (Some(oldPartitionMap), _)                         => oldPartitionMap.partitions
+                  case (_, _)                                             => SortedMap.empty[Int, KafkaConsumerGroupMetrics]
+                }
+                (topic, KafkaConsumerGroupTopicInfo(newPartitionMap))
+              )
+            SortedMap.from(tmp)
+
+          case (Some(oldTopicMap), _) => oldTopicMap.topics
+          case (_, _)                 => SortedMap.empty[String, KafkaConsumerGroupTopicInfo]
+        }
+        (group, KafkaConsumerGroupInfo(newTopicMap))
+      )
+      .toMap
+  }
+
 }

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupInfoCache.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupInfoCache.scala
@@ -92,7 +92,7 @@ object KafkaConsumerGroupInfoCache {
       .map(group =>
         val newTopicMap = (metricMap.get(group), addedOrUpdated.get(group)) match {
           case (Some(oldTopicMap), Some(newTopicMap)) =>
-            val tmp = oldTopicMap.topics.keySet.unsorted
+            val updatedTopicMap = oldTopicMap.topics.keySet.unsorted
               .union(newTopicMap.topics.keySet.unsorted)
               .map(topic =>
                 val newPartitionMap = (oldTopicMap.topics.get(topic), newTopicMap.topics.get(topic)) match {
@@ -101,7 +101,7 @@ object KafkaConsumerGroupInfoCache {
                 }
                 (topic, KafkaConsumerGroupTopicInfo(newPartitionMap))
               )
-            SortedMap.from(tmp)
+            SortedMap.from(updatedTopicMap)
           case (oldTopicMap, newTopicMap) => oldTopicMap.map(_.topics).orElse(newTopicMap.map(_.topics)).get
         }
         (group, KafkaConsumerGroupInfo(newTopicMap))
@@ -118,7 +118,7 @@ object KafkaConsumerGroupInfoCache {
       .map(group =>
         val newTopicMap = (metricMap.get(group), removed.get(group)) match {
           case (Some(oldTopicMap), Some(removedTopicMap)) =>
-            val tmp = oldTopicMap.topics.keySet.unsorted
+            val updatedTopicMap = oldTopicMap.topics.keySet.unsorted
               .union(removedTopicMap.keySet)
               .map(topic =>
                 val newPartitionMap = (oldTopicMap.topics.get(topic), removedTopicMap.get(topic)) match {
@@ -128,7 +128,7 @@ object KafkaConsumerGroupInfoCache {
                 }
                 (topic, KafkaConsumerGroupTopicInfo(newPartitionMap))
               )
-            SortedMap.from(tmp)
+            SortedMap.from(updatedTopicMap)
 
           case (Some(oldTopicMap), _) => oldTopicMap.topics
           case (_, _)                 => SortedMap.empty[String, KafkaConsumerGroupTopicInfo]

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupMetricsCalc.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupMetricsCalc.scala
@@ -210,7 +210,7 @@ class KafkaConsumerGroupMetricsCalc(
       .provideEnvironment(ZEnvironment(scope))
       .orDie
       .fork // TODO error handling!
-    // TODO not expecting subscribers after this -> those would not get the initial snapshot of topic infos, only diffs
+    // TODO not expecting subscribers after this -> those would not get the initial snapshot of consumer group metrics, only diffs
     // TODO check if we need to interrupt the fiber at all, maybe runScoped does it already?
     _ <- scope.addFinalizer(consumerGroupMetricsFiber.interrupt *> hub.shutdown *> ZIO.log("KafkaConsumerGroupMetricsCalc has shut down"))
   } yield ()

--- a/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupMetricsCalc.scala
+++ b/kafkakewl-metrics/src/main/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerGroupMetricsCalc.scala
@@ -1,0 +1,263 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Marshall Wace <opensource@mwam.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.mwam.kafkakewl.metrics.services
+
+import com.mwam.kafkakewl.metrics.domain.{
+  ConsumerGroupStatus,
+  ConsumerGroupTopicPartition,
+  KafkaConsumerGroupMetrics,
+  KafkaConsumerGroupOffset,
+  KafkaConsumerGroupOffsets,
+  KafkaTopicPartition,
+  KafkaTopicPartitionInfo,
+  KafkaTopicPartitionInfoChanges
+}
+import zio.{Dequeue, Duration, Fiber, Hub, Queue, Schedule, Scope, UIO, URIO, ZEnvironment, ZIO, ZLayer}
+import zio.stream.{ZSink, ZStream}
+
+case class KafkaConsumerGroupMetricChanges(
+    addedOrUpdated: Map[ConsumerGroupTopicPartition, KafkaConsumerGroupMetrics],
+    removed: Set[ConsumerGroupTopicPartition]
+)
+
+case class ConsumerGroupTopicPartitionMetricsWorker(
+    fibreHandle: Fiber[Nothing, Unit],
+    partitionInfoUpdate: Queue[KafkaTopicPartitionInfo],
+    consumerGroupUpdate: Queue[KafkaConsumerGroupOffset]
+)
+
+class ConsumerGroupMetricsManager(
+    val workerOutputQueue: Queue[KafkaConsumerGroupMetricChanges],
+    val workers: Map[ConsumerGroupTopicPartition, ConsumerGroupTopicPartitionMetricsWorker] = Map.empty,
+    val partitionConsumers: Map[KafkaTopicPartition, Set[ConsumerGroupTopicPartition]] = Map.empty,
+    val latestTopicPartitionInfos: Map[KafkaTopicPartition, KafkaTopicPartitionInfo] = Map.empty,
+    val latestConsumerGroupOffsets: Map[ConsumerGroupTopicPartition, KafkaConsumerGroupOffset] = Map.empty
+) {
+
+  def processKafkaConsumerGroupOffsets(groupOffsets: KafkaConsumerGroupOffsets): UIO[ConsumerGroupMetricsManager] = {
+    // Split groupOffsets by None-valued and Some-valued
+    val addedOrUpdated = groupOffsets.flatMap((k, v) => Some(k).zip(v))
+    val removed = groupOffsets.filter((_, v) => v.isEmpty).keySet
+    // Update the cache
+    val (newLatestConsumerGroupOffsets, addedKeys, removedGroupTopicPartition) =
+      ConsumerGroupMetricsManager.updateMapWithAddedRemoved(latestConsumerGroupOffsets, addedOrUpdated, removed)
+    for {
+
+      // Push the updates to current workers
+      _ <- ZIO.foreachParDiscard(addedOrUpdated) { (groupTopicPartition, groupOffset) =>
+        workers
+          .get(groupTopicPartition)
+          .map(worker => worker.consumerGroupUpdate.offer(groupOffset))
+          .getOrElse(ZIO.unit)
+      }
+
+      // Create new workers for new ConsumerGroupTopicPartition
+      addedWorkers <- ZIO.foreachPar(addedKeys) { consumerGroupTopicPartition =>
+        ZIO
+          .succeed(consumerGroupTopicPartition)
+          .zip(createNewWorkerFiber(consumerGroupTopicPartition, latestTopicPartitionInfos, newLatestConsumerGroupOffsets))
+      }
+
+      workersWithAdded = workers ++ addedWorkers
+
+      // Update partitionConsumers to reflect new and removed consumer groups
+      newPartitionConsumers = ConsumerGroupMetricsManager.updateMapOfSetsWithAddedRemoved(
+        partitionConsumers,
+        addedOrUpdated.map((cgtp, _) => (cgtp.topicPartition, cgtp)),
+        removed.map(cgtp => (cgtp.topicPartition, cgtp)).toMap
+      )
+
+      // Remove workers that have had nulls pushed to them, interrupting their fibres
+      _ <- ZIO.foreachParDiscard(removedGroupTopicPartition) { groupTopicPartition =>
+        workersWithAdded.get(groupTopicPartition).map(worker => worker.fibreHandle.interrupt).getOrElse(ZIO.unit) *> workerOutputQueue.offer(
+          KafkaConsumerGroupMetricChanges(Map.empty, Set(groupTopicPartition))
+        )
+      }
+      workersWithRemoved = workersWithAdded.removedAll(removedGroupTopicPartition)
+
+    } yield ConsumerGroupMetricsManager(
+      workerOutputQueue,
+      workersWithRemoved,
+      newPartitionConsumers,
+      latestTopicPartitionInfos,
+      newLatestConsumerGroupOffsets
+    )
+  }
+
+  private def createNewWorkerFiber(
+      consumerGroupTopicPartition: ConsumerGroupTopicPartition,
+      latestTopicPartitionInfos: Map[KafkaTopicPartition, KafkaTopicPartitionInfo],
+      latestConsumerGroupOffsets: Map[ConsumerGroupTopicPartition, KafkaConsumerGroupOffset]
+  ): UIO[ConsumerGroupTopicPartitionMetricsWorker] = {
+    for {
+      partitionInfoUpdate <- Queue.unbounded[KafkaTopicPartitionInfo]
+      _ <- ZIO.foreachDiscard(latestTopicPartitionInfos.get(consumerGroupTopicPartition.topicPartition))(topicPartitionInfo =>
+        partitionInfoUpdate.offer(topicPartitionInfo)
+      )
+      consumerGroupUpdate <- Queue.unbounded[KafkaConsumerGroupOffset]
+      _ <- ZIO.foreachDiscard(latestConsumerGroupOffsets.get(consumerGroupTopicPartition))(consumerGroupOffset =>
+        consumerGroupUpdate.offer(consumerGroupOffset)
+      )
+
+      workerFiber <- ZStream
+        .fromQueueWithShutdown(partitionInfoUpdate)
+        .mergeEither(ZStream.fromQueueWithShutdown(consumerGroupUpdate))
+        .runFoldZIO((Option.empty[KafkaTopicPartitionInfo], Option.empty[KafkaConsumerGroupOffset])) { (state, update) =>
+          // TODO: The window metric functions
+          val (newState) = update match {
+            case Left(kafkaTopicPartitionInfo)   => (Some(kafkaTopicPartitionInfo), state._2)
+            case Right(kafkaConsumerGroupOffset) => (state._1, Some(kafkaConsumerGroupOffset))
+          }
+          workerOutputQueue
+            .offer(
+              KafkaConsumerGroupMetricChanges(
+                Map(
+                  consumerGroupTopicPartition -> KafkaConsumerGroupMetrics(
+                    ConsumerGroupStatus.Ok,
+                    newState._1,
+                    newState._2,
+                    newState._1.zip(newState._2).map((tpi, cgo) => (tpi.endOffset - cgo.offset).max(0)),
+                    Some(0.0)
+                  )
+                ),
+                Set.empty
+              )
+            )
+            .as(newState)
+        }
+        .ignore
+        .fork
+    } yield ConsumerGroupTopicPartitionMetricsWorker(workerFiber, partitionInfoUpdate, consumerGroupUpdate)
+  }
+
+  def processKafkaTopicPartitionInfoChanges(topicPartitionInfoChanges: KafkaTopicPartitionInfoChanges): UIO[ConsumerGroupMetricsManager] = {
+    val addedOrUpdated = topicPartitionInfoChanges.addedOrUpdated
+    val removed = topicPartitionInfoChanges.removed
+    // Update the cache
+    val (newTopicPartitionInfos, _, _) =
+      ConsumerGroupMetricsManager.updateMapWithAddedRemoved(latestTopicPartitionInfos, addedOrUpdated, removed)
+
+    // Push the updates to current workers
+    val updatePushes = ZIO.foreachParDiscard(addedOrUpdated.flatMap { (topicPartition, topicPartitionInfo) =>
+      partitionConsumers
+        .get(topicPartition)
+        .toSet
+        .flatten
+        .map((_, topicPartitionInfo))
+    }) { (groupTopicPartition, topicPartitionInfo) =>
+      workers.get(groupTopicPartition).map(worker => worker.partitionInfoUpdate.offer(topicPartitionInfo)).getOrElse(ZIO.unit)
+    }
+
+    // Interrupt workers whose topic partitions have been removed, remove them from the worker map
+    val workerTerminations = ZIO.foreachParDiscard(removed.flatMap { topicPartition =>
+      partitionConsumers
+        .get(topicPartition)
+        .toSet
+        .flatten
+    }) { groupTopicPartition =>
+      workers.get(groupTopicPartition).map(worker => worker.fibreHandle.interrupt).getOrElse(ZIO.unit) *> workerOutputQueue.offer(
+        KafkaConsumerGroupMetricChanges(Map.empty, Set(groupTopicPartition))
+      )
+    }
+    val workersWithRemoved = workers.removedAll(removed.flatMap { topicPartition =>
+      partitionConsumers
+        .get(topicPartition)
+        .toSet
+    }.flatten)
+
+    // Update partitionConsumers to remove deleted partitions
+    val newPartitionConsumers = partitionConsumers.removedAll(removed)
+
+    updatePushes *> workerTerminations.as(
+      ConsumerGroupMetricsManager(workerOutputQueue, workersWithRemoved, newPartitionConsumers, newTopicPartitionInfos, latestConsumerGroupOffsets)
+    )
+  }
+}
+
+object ConsumerGroupMetricsManager {
+  // Returns tuple of new map, new keys, removed keys
+  def updateMapWithAddedRemoved[K, V](oldMap: Map[K, V], addedOrUpdated: Map[K, V], removed: Set[K]): (Map[K, V], Set[K], Set[K]) = {
+    val newMap =
+      oldMap.keySet.union(addedOrUpdated.keySet).map(key => (key, oldMap.get(key).orElse(addedOrUpdated.get(key)).get)).toMap.removedAll(removed)
+    val newKeys = addedOrUpdated.keySet.diff(oldMap.keySet)
+    val removedKeys = oldMap.keySet.intersect(removed)
+    (newMap, newKeys, removedKeys)
+  }
+
+  def updateMapOfSetsWithAddedRemoved[K, V](oldMap: Map[K, Set[V]], addedOrUpdated: Map[K, V], removed: Map[K, V]): Map[K, Set[V]] = {
+    val newMap =
+      oldMap.keySet
+        .union(addedOrUpdated.keySet)
+        .map(key => (key, oldMap(key).union(addedOrUpdated.get(key).toSet).removedAll(removed.get(key))))
+        .toMap
+    newMap
+  }
+}
+
+class KafkaConsumerGroupMetricsCalc(
+    private val scope: Scope, // TODO This is slightly dangerous, the scope must not be used after it's closed
+    private val consumerGroupMetricsStream: ZStream[Any, Throwable, KafkaConsumerGroupMetricChanges],
+    private val hub: Hub[KafkaConsumerGroupMetricChanges]
+) {
+  def subscribe(): URIO[Scope, Dequeue[KafkaConsumerGroupMetricChanges]] = hub.subscribe
+  def startPublishing(): UIO[Unit] = for {
+    consumerGroupMetricsFiber <- consumerGroupMetricsStream
+      .runScoped(ZSink.foreach(hub.publish))
+      .provideEnvironment(ZEnvironment(scope))
+      .orDie
+      .fork // TODO error handling!
+    // TODO not expecting subscribers after this -> those would not get the initial snapshot of topic infos, only diffs
+    // TODO check if we need to interrupt the fiber at all, maybe runScoped does it already?
+    _ <- scope.addFinalizer(consumerGroupMetricsFiber.interrupt *> hub.shutdown *> ZIO.log("KafkaConsumerGroupMetricsCalc has shut down"))
+  } yield ()
+}
+
+object KafkaConsumerGroupMetricsCalc {
+
+  def live: ZLayer[ConsumerOffsetsSource & KafkaTopicInfoSource, Nothing, KafkaConsumerGroupMetricsCalc] =
+    ZLayer.scoped {
+      for {
+        scope <- ZIO.service[Scope]
+        consumerOffsetSource <- ZIO.service[ConsumerOffsetsSource]
+        consumerOffsetStream <- consumerOffsetSource.subscribe().map(ZStream.fromQueueWithShutdown(_))
+        topicInfoSource <- ZIO.service[KafkaTopicInfoSource]
+        topicInfoStream <- topicInfoSource.subscribe().map(ZStream.fromQueueWithShutdown(_))
+        hub <- Hub.bounded[KafkaConsumerGroupMetricChanges](requestedCapacity = 1)
+        groupMetricsStream <- createConsumerGroupMetricStream(consumerOffsetStream, topicInfoStream)
+      } yield KafkaConsumerGroupMetricsCalc(scope, groupMetricsStream, hub)
+    }
+
+  private def createConsumerGroupMetricStream(
+      consumerOffsetStream: ZStream[Any, Nothing, KafkaConsumerGroupOffsets],
+      topicInfoStream: ZStream[Any, Nothing, KafkaTopicPartitionInfoChanges]
+  ): UIO[ZStream[Any, Throwable, KafkaConsumerGroupMetricChanges]] = for {
+    // Manager loop merges the two relevant streams and processes each message individually in a fold
+    outputQueue <- Queue.unbounded[KafkaConsumerGroupMetricChanges]
+    _ <- consumerOffsetStream
+      .mergeEither(topicInfoStream)
+      .runFoldZIO(new ConsumerGroupMetricsManager(outputQueue)) { (manager, update) =>
+        update match {
+          case Left(kafkaConsumerGroupOffsets)       => manager.processKafkaConsumerGroupOffsets(kafkaConsumerGroupOffsets)
+          case Right(kafkaTopicPartitionInfoChanges) => manager.processKafkaTopicPartitionInfoChanges(kafkaTopicPartitionInfoChanges)
+        }
+      }
+      .fork
+  } yield ZStream
+    .fromQueueWithShutdown(outputQueue)
+    .aggregateAsyncWithin(ZSink.collectAll[KafkaConsumerGroupMetricChanges], Schedule.fixed(Duration.fromSeconds(1)))
+    .map { updates =>
+
+      val addedOrUpdated =
+        updates.map(_.addedOrUpdated).foldLeft(Map.empty[ConsumerGroupTopicPartition, KafkaConsumerGroupMetrics]) { (accum, update) =>
+          accum ++ update
+        }
+      val removed = updates.map(_.removed).foldLeft(Set.empty[ConsumerGroupTopicPartition]) { (accum, update) =>
+        accum ++ update
+      }
+      KafkaConsumerGroupMetricChanges(addedOrUpdated, removed)
+    }
+}

--- a/kafkakewl-metrics/src/test/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerMetricsCalcTest.scala
+++ b/kafkakewl-metrics/src/test/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerMetricsCalcTest.scala
@@ -1,0 +1,272 @@
+package com.mwam.kafkakewl.metrics.services
+
+import com.mwam.kafkakewl.metrics.domain.{
+  ConsumerGroupStatus,
+  ConsumerGroupTopicPartition,
+  KafkaConsumerGroupMetrics,
+  KafkaConsumerGroupOffset,
+  KafkaConsumerGroupOffsets,
+  KafkaTopicPartition,
+  KafkaTopicPartitionInfo,
+  KafkaTopicPartitionInfoChanges
+}
+import com.mwam.kafkakewl.metrics.services.KafkaConsumerMetricsCalcTest.test
+import zio.stream.ZStream
+import zio.{Duration, Queue, UIO, ZIO}
+import zio.test.{Spec, TestAspect, ZIOSpecDefault, assertTrue}
+
+import java.time.{Instant, OffsetDateTime}
+
+object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
+
+  def getConsumerMetricsCalc(
+      topicQueue: Queue[KafkaTopicPartitionInfoChanges],
+      consumerInfoQueue: Queue[KafkaConsumerGroupOffsets]
+  ): UIO[ZStream[Any, Nothing, KafkaConsumerGroupMetricChanges]] =
+    KafkaConsumerGroupMetricsCalc.createConsumerGroupMetricStream(ZStream.fromQueue(consumerInfoQueue), ZStream.fromQueue(topicQueue))
+
+  def getQueuesAndMetricsCalc: ZIO[
+    Any,
+    Nothing,
+    (Queue[KafkaTopicPartitionInfoChanges], Queue[KafkaConsumerGroupOffsets], ZStream[Any, Nothing, KafkaConsumerGroupMetricChanges])
+  ] = for {
+    topicQueue <- Queue.bounded[KafkaTopicPartitionInfoChanges](1)
+    consumerQueue <- Queue.bounded[KafkaConsumerGroupOffsets](1)
+    cmc <- getConsumerMetricsCalc(topicQueue, consumerQueue)
+  } yield (topicQueue, consumerQueue, cmc)
+
+  def pushTestConsumerGroup(
+      cmc: ZStream[Any, Nothing, KafkaConsumerGroupMetricChanges],
+      consumerQueue: Queue[KafkaConsumerGroupOffsets]
+  ): UIO[KafkaConsumerGroupMetricChanges] = for {
+    _ <- consumerQueue.offer(
+      Map.newBuilder
+        .addOne(ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)))
+        .result()
+    )
+    result <- cmc.take(1).runCollect
+  } yield result(0)
+
+  def pushTestTopic(
+      cmc: ZStream[Any, Nothing, KafkaConsumerGroupMetricChanges],
+      topicQueue: Queue[KafkaTopicPartitionInfoChanges]
+  ): UIO[KafkaConsumerGroupMetricChanges] = for {
+    _ <- topicQueue.offer(
+      KafkaTopicPartitionInfoChanges(
+        Map.newBuilder
+          .addOne(KafkaTopicPartition("testTopic", 0) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX))
+          .result(),
+        Set.empty
+      )
+    )
+    result <- cmc.take(1).runCollect
+  } yield result(0)
+
+  def deleteTestConsumerGroup(
+      cmc: ZStream[Any, Nothing, KafkaConsumerGroupMetricChanges],
+      consumerQueue: Queue[KafkaConsumerGroupOffsets]
+  ): UIO[KafkaConsumerGroupMetricChanges] = for {
+    _ <- consumerQueue
+      .offer(
+        Map.newBuilder
+          .addOne(ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> None)
+          .result()
+      )
+    result <- cmc.take(1).runCollect
+  } yield result(0)
+
+  def deleteTestTopic(
+      cmc: ZStream[Any, Nothing, KafkaConsumerGroupMetricChanges],
+      topicQueue: Queue[KafkaTopicPartitionInfoChanges]
+  ): UIO[KafkaConsumerGroupMetricChanges] = for {
+    _ <- topicQueue
+      .offer(
+        KafkaTopicPartitionInfoChanges(
+          Map.empty,
+          Set(KafkaTopicPartition("testTopic", 0))
+        )
+      )
+    result <- cmc.take(1).runCollect
+  } yield result(0)
+
+  def kafkaConsumerGroupMetricChangesWithoutTopic: KafkaConsumerGroupMetricChanges = KafkaConsumerGroupMetricChanges(
+    Map.newBuilder
+      .addOne(
+        ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
+          ConsumerGroupStatus.Ok,
+          None,
+          Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
+          None,
+          Some(0.0)
+        )
+      )
+      .result(),
+    Set.empty
+  )
+
+  def kafkaConsumerGroupMetricChangesWithTopic: KafkaConsumerGroupMetricChanges = KafkaConsumerGroupMetricChanges(
+    Map.newBuilder
+      .addOne(
+        ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
+          ConsumerGroupStatus.Ok,
+          Some(KafkaTopicPartitionInfo(20, 3, Instant.MAX)),
+          Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
+          Some(0),
+          Some(0.0)
+        )
+      )
+      .result(),
+    Set.empty
+  )
+
+  def kafkaConsumerGroupMetricChangesRemoved: KafkaConsumerGroupMetricChanges = KafkaConsumerGroupMetricChanges(
+    Map.empty,
+    Set(ConsumerGroupTopicPartition("testGroup", "testTopic", 0))
+  )
+
+  def spec: Spec[Any, Nothing] = suite("KafkaConsumerMetricsCalc Tests")(
+    test("Adding a kafka consumer group starts adding consumer group metrics") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (_, consumerQueue, cmc) = start
+        firstResult <- pushTestConsumerGroup(cmc, consumerQueue)
+
+      } yield assertTrue(
+        firstResult == KafkaConsumerGroupMetricChanges(
+          Map.newBuilder
+            .addOne(
+              ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
+                ConsumerGroupStatus.Ok,
+                None,
+                Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
+                None,
+                Some(0.0)
+              )
+            )
+            .result(),
+          Set.empty
+        )
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Nulling a kafka consumer group removes consumer group metrics") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (_, consumerQueue, cmc) = start
+
+        firstResult <- pushTestConsumerGroup(cmc, consumerQueue)
+        secondResult <- deleteTestConsumerGroup(cmc, consumerQueue)
+
+      } yield assertTrue(
+        firstResult == kafkaConsumerGroupMetricChangesWithoutTopic &&
+          secondResult == kafkaConsumerGroupMetricChangesRemoved
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Adding a topic then consumer metric with both") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (topicQueue, consumerQueue, cmc) = start
+
+        _ <- topicQueue
+          .offer(
+            KafkaTopicPartitionInfoChanges(
+              Map.newBuilder
+                .addOne(KafkaTopicPartition("testTopic", 0) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX))
+                .result(),
+              Set.empty
+            )
+          )
+
+        // As the queue is bounded to 1 we wait until the last finished processing
+        _ <- topicQueue.offer(
+          KafkaTopicPartitionInfoChanges(
+            Map.newBuilder
+              .addOne(KafkaTopicPartition("testTopic", 1) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX))
+              .result(),
+            Set.empty
+          )
+        )
+
+        firstResult <- pushTestConsumerGroup(cmc, consumerQueue)
+
+      } yield assertTrue(
+        firstResult == kafkaConsumerGroupMetricChangesWithTopic
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Adding a consumer then topic produces two outputs (without then with the topic info)") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (topicQueue, consumerQueue, cmc) = start
+
+        firstResult <- pushTestConsumerGroup(cmc, consumerQueue)
+        secondResult <- pushTestTopic(cmc, topicQueue)
+      } yield assertTrue(
+        firstResult == kafkaConsumerGroupMetricChangesWithoutTopic &&
+          secondResult == kafkaConsumerGroupMetricChangesWithTopic
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Removing a topic deletes the metric") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (topicQueue, consumerQueue, cmc) = start
+
+        _ <- pushTestConsumerGroup(cmc, consumerQueue)
+        firstResult <- pushTestTopic(cmc, topicQueue)
+
+        secondResult <- deleteTestTopic(cmc, topicQueue)
+
+      } yield assertTrue(
+        firstResult == kafkaConsumerGroupMetricChangesWithTopic &&
+          secondResult == kafkaConsumerGroupMetricChangesRemoved
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Removing a topic and republishing does nothing") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (topicQueue, consumerQueue, cmc) = start
+
+        _ <- pushTestConsumerGroup(cmc, consumerQueue)
+        _ <- pushTestTopic(cmc, topicQueue)
+
+        _ <- deleteTestTopic(cmc, topicQueue)
+
+        neverFinishes <- pushTestTopic(cmc, topicQueue).timeout(Duration.fromSeconds(5))
+
+      } yield assertTrue(
+        neverFinishes.isEmpty
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Removing a topic and republishing consumer does nothing") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (topicQueue, consumerQueue, cmc) = start
+
+        _ <- pushTestConsumerGroup(cmc, consumerQueue)
+        _ <- pushTestTopic(cmc, topicQueue)
+
+        _ <- deleteTestTopic(cmc, topicQueue)
+
+        neverFinishes <- pushTestConsumerGroup(cmc, consumerQueue).timeout(Duration.fromSeconds(5))
+
+      } yield assertTrue(
+        neverFinishes.isEmpty
+      )
+    } @@ TestAspect.withLiveClock,
+    test("Removing a topic and consumer then republishing consumer publishes metrics without topic") {
+      for {
+        start <- getQueuesAndMetricsCalc
+        (topicQueue, consumerQueue, cmc) = start
+
+        _ <- pushTestConsumerGroup(cmc, consumerQueue)
+        _ <- pushTestTopic(cmc, topicQueue)
+
+        _ <- deleteTestTopic(cmc, topicQueue)
+
+        _ <- deleteTestConsumerGroup(cmc, consumerQueue)
+        result <- pushTestConsumerGroup(cmc, consumerQueue)
+
+      } yield assertTrue(
+        result == kafkaConsumerGroupMetricChangesWithoutTopic
+      )
+    } @@ TestAspect.withLiveClock
+  )
+}

--- a/kafkakewl-metrics/src/test/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerMetricsCalcTest.scala
+++ b/kafkakewl-metrics/src/test/scala/com/mwam/kafkakewl/metrics/services/KafkaConsumerMetricsCalcTest.scala
@@ -40,9 +40,7 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
       consumerQueue: Queue[KafkaConsumerGroupOffsets]
   ): UIO[KafkaConsumerGroupMetricChanges] = for {
     _ <- consumerQueue.offer(
-      Map.newBuilder
-        .addOne(ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)))
-        .result()
+      Map(ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)))
     )
     result <- cmc.take(1).runCollect
   } yield result(0)
@@ -53,9 +51,7 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
   ): UIO[KafkaConsumerGroupMetricChanges] = for {
     _ <- topicQueue.offer(
       KafkaTopicPartitionInfoChanges(
-        Map.newBuilder
-          .addOne(KafkaTopicPartition("testTopic", 0) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX))
-          .result(),
+        Map(KafkaTopicPartition("testTopic", 0) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX)),
         Set.empty
       )
     )
@@ -68,9 +64,7 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
   ): UIO[KafkaConsumerGroupMetricChanges] = for {
     _ <- consumerQueue
       .offer(
-        Map.newBuilder
-          .addOne(ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> None)
-          .result()
+        Map(ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> None)
       )
     result <- cmc.take(1).runCollect
   } yield result(0)
@@ -90,32 +84,28 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
   } yield result(0)
 
   def kafkaConsumerGroupMetricChangesWithoutTopic: KafkaConsumerGroupMetricChanges = KafkaConsumerGroupMetricChanges(
-    Map.newBuilder
-      .addOne(
-        ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
-          ConsumerGroupStatus.Ok,
-          None,
-          Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
-          None,
-          Some(0.0)
-        )
+    Map(
+      ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
+        ConsumerGroupStatus.Ok,
+        None,
+        Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
+        None,
+        Some(0.0)
       )
-      .result(),
+    ),
     Set.empty
   )
 
   def kafkaConsumerGroupMetricChangesWithTopic: KafkaConsumerGroupMetricChanges = KafkaConsumerGroupMetricChanges(
-    Map.newBuilder
-      .addOne(
-        ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
-          ConsumerGroupStatus.Ok,
-          Some(KafkaTopicPartitionInfo(20, 3, Instant.MAX)),
-          Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
-          Some(0),
-          Some(0.0)
-        )
+    Map(
+      ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
+        ConsumerGroupStatus.Ok,
+        Some(KafkaTopicPartitionInfo(20, 3, Instant.MAX)),
+        Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
+        Some(0),
+        Some(0.0)
       )
-      .result(),
+    ),
     Set.empty
   )
 
@@ -132,20 +122,7 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
         firstResult <- pushTestConsumerGroup(cmc, consumerQueue)
 
       } yield assertTrue(
-        firstResult == KafkaConsumerGroupMetricChanges(
-          Map.newBuilder
-            .addOne(
-              ConsumerGroupTopicPartition("testGroup", "testTopic", 0) -> KafkaConsumerGroupMetrics(
-                ConsumerGroupStatus.Ok,
-                None,
-                Some(KafkaConsumerGroupOffset(123, "", OffsetDateTime.MAX)),
-                None,
-                Some(0.0)
-              )
-            )
-            .result(),
-          Set.empty
-        )
+        firstResult == kafkaConsumerGroupMetricChangesWithoutTopic
       )
     } @@ TestAspect.withLiveClock,
     test("Nulling a kafka consumer group removes consumer group metrics") {
@@ -169,9 +146,7 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
         _ <- topicQueue
           .offer(
             KafkaTopicPartitionInfoChanges(
-              Map.newBuilder
-                .addOne(KafkaTopicPartition("testTopic", 0) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX))
-                .result(),
+              Map(KafkaTopicPartition("testTopic", 0) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX)),
               Set.empty
             )
           )
@@ -179,9 +154,7 @@ object KafkaConsumerMetricsCalcTest extends ZIOSpecDefault {
         // As the queue is bounded to 1 we wait until the last finished processing
         _ <- topicQueue.offer(
           KafkaTopicPartitionInfoChanges(
-            Map.newBuilder
-              .addOne(KafkaTopicPartition("testTopic", 1) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX))
-              .result(),
+            Map(KafkaTopicPartition("testTopic", 1) -> KafkaTopicPartitionInfo(20, 3, Instant.MAX)),
             Set.empty
           )
         )


### PR DESCRIPTION
This PR lays the groundwork for implementing Consumer Group Statistics in the same way that the legacy Kafkakewl did.

Still Todo:
- Tests
- Metric window calculation logic