### PR TITLE
Parallelized validations and logging/metrics

### DIFF
--- a/kewl-api/src/main/resources/prometheus.yaml
+++ b/kewl-api/src/main/resources/prometheus.yaml
@@ -39,3 +39,11 @@ rules:
       kafkaCluster: "$1"
       topic: "$2"
       type: "$3"
+  - pattern: 'kafkakewl-api<name=\"com\.mwam\.kafkakewl\.processor\.kafkacluster\.deploy\.(.+)\:(.+)\"><>(.+): (.+)'
+    type: UNTYPED
+    name: "kafkakewl_deploy_duration"
+    value: "$4"
+    labels:
+      operation: "$1"
+      kafkaCluster: "$2"
+      type: "$3"

--- a/kewl-api/src/main/scala/com/mwam/kafkakewl/api/HttpServerApp.scala
+++ b/kewl-api/src/main/scala/com/mwam/kafkakewl/api/HttpServerApp.scala
@@ -45,7 +45,9 @@ object HttpServerApp extends App
   implicit val system: ActorSystem = ActorSystem("kafkakewl-api")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
-  // the time-out needs to be longer than usual, because some operations can be really slow (e.g. topic deletion)
+  // the time-out needs to be longer than usual, because
+  // - some operations can be really slow (e.g. topic deletion)
+  // - deployments are queued up and performed sequentially - under load the queueing time might be quite long
   implicit val timeout: Timeout = 10.minutes
 
   val jmpReporter: JmxReporter = JmxReporter.forRegistry(metricRegistry).inDomain("kafkakewl-api").build

--- a/kewl-api/src/main/scala/com/mwam/kafkakewl/api/actors/CommandProcessorActor.scala
+++ b/kewl-api/src/main/scala/com/mwam/kafkakewl/api/actors/CommandProcessorActor.scala
@@ -8,6 +8,7 @@ package com.mwam.kafkakewl.api.actors
 
 import akka.actor.Actor
 import akka.pattern.{ask, pipe}
+import akka.util.Timeout
 import cats.data.EitherT
 import cats.instances.future._
 import com.mwam.kafkakewl.common._
@@ -44,7 +45,7 @@ class CommandProcessorActor(
   val permissionStoreBuiltinExtensionOrNone: Option[PermissionStoreBuiltin],
   createStateCommandProcessor: Boolean => StateCommandProcessor,
   val topicDefaults: TopicDefaults
-) extends Actor
+)(override implicit val timeout: Timeout) extends Actor
   // not using akka's ActorLogging because that's async and everywhere else we use the normal LazyLogging (performance won't matter anyway)
   with ActorPreRestartLog
   with CommandProcessorExtensions

--- a/kewl-common/src/main/scala/com/mwam/kafkakewl/common/validation/TopologyToDeployValidatorWithOthers.scala
+++ b/kewl-common/src/main/scala/com/mwam/kafkakewl/common/validation/TopologyToDeployValidatorWithOthers.scala
@@ -82,6 +82,7 @@ object TopologyToDeployValidatorWithOthers {
     // the new topology may impact the existing topologies' dependencies (e.g. removing a shared topic that's referenced is invalid)
     val existingTopologyDependenciesValidationResult =
       (currentTopologiesMap - newTopologyId)
+        .par
         .map { case (existingTopologyId, existingTopology) =>
           validateTopologyExternalDependencies(
             allowedCustomRelationships,
@@ -96,7 +97,9 @@ object TopologyToDeployValidatorWithOthers {
             visibilityErrorToStringForDependents(existingTopologyId, newTopologyId),
             topicDefaults
           )
-        }.toSeq.combine()
+        }
+        .seq
+        .toSeq.combine()
 
     val otherTopologiesMap = currentTopologiesMap - newTopologyId
 

--- a/kewl-common/src/main/scala/com/mwam/kafkakewl/common/validation/TopologyValidatorWithOthers.scala
+++ b/kewl-common/src/main/scala/com/mwam/kafkakewl/common/validation/TopologyValidatorWithOthers.scala
@@ -40,6 +40,7 @@ object TopologyValidatorWithOthers {
     // the new topology may impact the existing topologies' dependencies (e.g. removing a shared topic that's referenced is invalid)
     val existingTopologyDependenciesValidationResult =
       (currentTopologiesMap - newTopologyId)
+        .par
         .map { case (existingTopologyId, existingTopology) =>
           validateTopologyExternalDependencies(
             allowedCustomRelationships,
@@ -54,7 +55,9 @@ object TopologyValidatorWithOthers {
             visibilityErrorToStringForDependents(existingTopologyId, newTopologyId),
             topicDefaults
           )
-        }.toSeq.combine()
+        }
+        .seq
+        .toSeq.combine()
 
     newTopologyDependenciesValidationResult ++ existingTopologyDependenciesValidationResult
   }

--- a/kewl-utils/src/main/scala/com/mwam/kafkakewl/utils/package.scala
+++ b/kewl-utils/src/main/scala/com/mwam/kafkakewl/utils/package.scala
@@ -47,7 +47,7 @@ package object utils {
     (result, duration)
   }
 
-  def withDurationOf[T](action: => T)(handler: Duration => Unit): T = {
+  def withDurationOf[T](action: => T)(handler: FiniteDuration => Unit): T = {
     val (r, d) = durationOf[T](action)
     handler(d)
     r


### PR DESCRIPTION
Deploying topologies have become really slow, 7-8 seconds. About half of it was the validation logic, the other half was getting the kafka topics/acls from the kafka cluster.

This PR does the obvious optimization: does some parts of the validation parallel to make it faster. Locally the validation's duration went down from 3-4 seconds to 800 - 1200 ms.