### PR TITLE
kafkakewl-api: akka.http.max-to-strict-bytes = infinite so that the m…

### DIFF
--- a/kewl-api/src/main/resources/application.conf
+++ b/kewl-api/src/main/resources/application.conf
@@ -25,6 +25,14 @@ akka.http.server {
   }
 }
 
+akka.http {
+  parsing {
+    # So that http client does not complain about the response being too large
+    # (the default is 8mb which isn't always enough, if e.g. there are more than 1500 consumer groups to query for statuses)
+    max-to-strict-bytes = infinite
+  }
+}
+
 kafkakewl-api {
   env = "dev"
   env = ${?KAFKAKEWL_API_ENV}


### PR DESCRIPTION
…etrics' response can be large