### PR TITLE
don't give developers the application's consumer group ACL in empty n…

### DIFF
--- a/kewl-kafkacluster-processor/src/main/scala/com/mwam/kafkakewl/processor/kafkacluster/deployment/KafkaClusterItems.scala
+++ b/kewl-kafkacluster-processor/src/main/scala/com/mwam/kafkakewl/processor/kafkacluster/deployment/KafkaClusterItems.scala
@@ -381,9 +381,11 @@ private[kafkacluster] object KafkaClusterItems extends TopologyLikeOperations[To
     // topics, acls, etc...
     val topics = topologyToDeploy.fullyQualifiedTopics.values.flatMap(forTopic(resolveTopicConfig)).map(KafkaClusterItemOfTopology(_, topologyId))
 
-    // if the topology is in the root namespace (i.e. empty string), its developers will be additional users of all applications
-    // this is like this to compensate for the lack of namespace prefix acls for developers (we don't want to give developers * permissions for everything,#
+    // if the topology is in the root namespace (i.e. empty string), its developers will be additional users of all application-topic relationships
+    // this is like this to compensate for the lack of namespace prefix acls for developers (we don't want to give developers * permissions for everything,
     // just because the topology doesn't have a namespace)
+    // note: developers are NOT added as additional users of applications themselves (forApplication) to avoid giving them the application's
+    // consumer group ACL, which would allow them to join the group and trigger rebalances. Developers have their own personal consumer groups instead.
     val additionalApplicationDevelopers = if (topologyToDeploy.namespace.isEmpty) {
       topologyToDeploy.developers
     } else {
@@ -397,7 +399,7 @@ private[kafkacluster] object KafkaClusterItems extends TopologyLikeOperations[To
     }
 
     val consumerGroupAcls = topologyToDeploy.fullyQualifiedApplications
-      .flatMap { case (id, a) => forApplication(a, consumingApplicationIds.contains(id), additionalApplicationDevelopers) }
+      .flatMap { case (id, a) => forApplication(a, consumingApplicationIds.contains(id)) }
       .map(KafkaClusterItemOfTopology(_, topologyId))
 
     developerAcls ++

--- a/kewl-kafkacluster-processor/src/test/scala/com/mwam/kafkakewl/processor/kafkacluster/deployment/KafkaClusterItemsSpec.scala
+++ b/kewl-kafkacluster-processor/src/test/scala/com/mwam/kafkakewl/processor/kafkacluster/deployment/KafkaClusterItemsSpec.scala
@@ -438,11 +438,11 @@ class KafkaClusterItemsSpec extends FlatSpec with TestTopologiesToDeploy with Te
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:service-test-processor", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:service-test-processor", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.CLUSTER, PatternType.LITERAL, "kafka-cluster", "User:developer1", "*", AclOperation.IDEMPOTENT_WRITE, AclPermissionType.ALLOW).toTuple,
-        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.LITERAL, "test.processor", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
+        // developer1 uses personal consumer group "user.developer1.*" instead of the application's group to avoid rebalancing
+        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.PREFIXED, "user.developer1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
-        KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple,
-        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.PREFIXED, "user.developer1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple
+        KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple
       ).mapValues(_.withOwnerTopologyId(TopologyEntityId("test")))
 
     assert(actualKafkaClusterItems == expectedKafkaClusterItems)
@@ -480,11 +480,11 @@ class KafkaClusterItemsSpec extends FlatSpec with TestTopologiesToDeploy with Te
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:service-test-processor", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:service-test-processor", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.CLUSTER, PatternType.LITERAL, "kafka-cluster", "User:developer1", "*", AclOperation.IDEMPOTENT_WRITE, AclPermissionType.ALLOW).toTuple,
-        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.LITERAL, "test.processor", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
+        // developer1 uses personal consumer group "user.developer1.*" instead of the application's group to avoid rebalancing
+        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.PREFIXED, "user.developer1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
-        KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple,
-        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.PREFIXED, "user.developer1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple
+        KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple
       ).mapValues(_.withOwnerTopologyId(TopologyEntityId("test")))
 
     assert(actualKafkaClusterItems == expectedKafkaClusterItems)
@@ -1663,8 +1663,8 @@ class KafkaClusterItemsSpec extends FlatSpec with TestTopologiesToDeploy with Te
         // developer1 (full access, empty namespace) developer ACLs
         KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.PREFIXED, "user.developer1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.CLUSTER, PatternType.LITERAL, "kafka-cluster", "User:developer1", "*", AclOperation.IDEMPOTENT_WRITE, AclPermissionType.ALLOW).toTuple,
-        // developer1 as additional application user (empty namespace compensation)
-        KafkaClusterItem.Acl(ResourceType.GROUP, PatternType.LITERAL, "test.processor", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
+        // developer1 as additional application user (empty namespace compensation): topic ACLs only, no app consumer group
+        // (developers use their personal consumer group "user.developer1.*" to avoid rebalancing the application's group)
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.READ, AclPermissionType.ALLOW).toTuple,
         KafkaClusterItem.Acl(ResourceType.TOPIC, PatternType.LITERAL, "test.topic1", "User:developer1", "*", AclOperation.WRITE, AclPermissionType.ALLOW).toTuple,


### PR DESCRIPTION
…amespace topologies

Developers in empty-namespace topologies were getting GROUP READ on the application's consumer group (e.g. "test.processor"), which allowed them to join the group and trigger partition rebalances. Developers already have their own personal consumer group prefix ("user.<developer>.*") from forDevelopers, so they can consume topics without interfering with application consumer groups.